### PR TITLE
Disable _next listing when deployed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,44 @@
+{
+  "redirects": [
+    {
+      "source": "/_next",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/data",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/data/([A-z0-9_-]{21})",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/static",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/static/([A-z0-9_-]{21})",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/static/chunks",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/static/css",
+      "destination": "/404",
+      "statusCode": 404
+    },
+    {
+      "source": "/_next/static/images",
+      "destination": "/404",
+      "statusCode": 404
+    }
+  ]
+}


### PR DESCRIPTION
Looks like `/_next` lists all of our assets.  Not that there's anything secret in there, but it's annoying.  We can use `vercel.json` to redirect visitors to these index routes somewhere else.  We can't know the full routes of all the data in `_next/data`, but since these are etag-like slugs, they will be reasonably hard to guess. 

Thanks to https://stackoverflow.com/questions/62614474/how-to-disable-directory-listing-in-next-js-deployed-to-vercel

<img width="1495" alt="Screen Shot 2020-10-25 at 2 03 50 PM" src="https://user-images.githubusercontent.com/303226/97119047-e9ffea80-16ca-11eb-941a-e6a599e24008.png">
