### PR TITLE
fix rendering of job descriptions

### DIFF
--- a/pages/jobs/[id].tsx
+++ b/pages/jobs/[id].tsx
@@ -45,10 +45,15 @@ function JobCard({ job }: { job: LeverJob }) {
         >
           Apply Now
         </Button>
-        <br />
-        <br />
 
-        <Card.Text dangerouslySetInnerHTML={{ __html: job.description }} />
+        <hr />
+
+        <div
+          id="job-description"
+          dangerouslySetInnerHTML={{ __html: job.description }}
+        />
+
+        <br />
 
         {job.lists.map((listItem) => (
           <Fragment key={`job-${job.id}-list-${listItem.text}`}>


### PR DESCRIPTION
`<Card.Text>` is a `<p>` under the hood, and when rendering on the server, it drops any `<div>` content contained within.

<img width="1219" alt="Screen Shot 2020-11-11 at 9 52 19 AM" src="https://user-images.githubusercontent.com/303226/98846198-98ae6580-2403-11eb-9c95-1ef4c0b1d128.png">
