### PR TITLE
Add property rule operations dictionary to Create Groups doc

### DIFF
--- a/components/docs/index.tsx
+++ b/components/docs/index.tsx
@@ -1,0 +1,5 @@
+import Image from "./image";
+import HavingProblems from "./havingProblems";
+import RuleOpsTable from "./ruleOpsTable";
+
+export { Image, HavingProblems, RuleOpsTable };

--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -1,0 +1,118 @@
+import { Fragment } from "react";
+import { Accordion, Button, Tabs, Tab, Table } from "react-bootstrap";
+import pgRuleOps from "../../data/property-ops-dictionary--postgres.json";
+import sqliteRuleOps from "../../data/property-ops-dictionary--sqlite.json";
+
+const propertyTypes = [
+  "boolean",
+  "date",
+  "email",
+  "float",
+  "integer",
+  "phoneNumber",
+  "string",
+  "url",
+];
+
+interface PropertyOperations {
+  description: string;
+  op: string;
+}
+
+interface RuleOpsDbTypeData {
+  boolean: any;
+  date: any;
+  email: any;
+  float: any;
+  integer: any;
+  phoneNumber: any;
+  string: any;
+  url: any;
+  [key: string]: any;
+}
+
+interface RuleOpsDbType {
+  key: string;
+  title: string;
+  data: RuleOpsDbTypeData;
+}
+
+const ruleOpsData: RuleOpsDbType[] = [
+  {
+    key: "pg",
+    title: "Postgres",
+    data: pgRuleOps,
+  },
+  {
+    key: "sqlite",
+    title: "SQLite",
+    data: sqliteRuleOps,
+  },
+];
+
+const DataTable = ({ data, heading, eventKey }) => {
+  return (
+    <Fragment>
+      <Accordion.Toggle
+        as={Button}
+        variant="link"
+        eventKey={eventKey}
+        style={{ display: "block", paddingLeft: "0" }}
+      >
+        <h4>{heading}</h4>
+      </Accordion.Toggle>
+      <Accordion.Collapse eventKey={eventKey}>
+        <Fragment>
+          <p>
+            The following operators are available on <code>{heading}</code>{" "}
+            properties:
+          </p>
+          <Table>
+            <thead>
+              <tr>
+                <th>Operator</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((item, idx) => (
+                <tr key={idx}>
+                  <td>
+                    <code>{item.op}</code>
+                  </td>
+                  <td>{item.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </Fragment>
+      </Accordion.Collapse>
+    </Fragment>
+  );
+};
+
+export default function RuleOpsTable() {
+  return (
+    <Tabs defaultActiveKey={ruleOpsData[0].key}>
+      {ruleOpsData.map(({ data, key: dbKey, title }, idx) => (
+        <Tab
+          key={dbKey}
+          eventKey={dbKey}
+          title={title}
+          style={{ padding: "1rem" }}
+        >
+          <Accordion defaultActiveKey={`${dbKey}-${propertyTypes[0]}`}>
+            {propertyTypes.map((typeKey) => (
+              <DataTable
+                key={typeKey}
+                eventKey={`${dbKey}-${typeKey}`}
+                heading={typeKey}
+                data={data[typeKey]}
+              />
+            ))}
+          </Accordion>
+        </Tab>
+      ))}
+    </Tabs>
+  );
+}

--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -20,14 +20,14 @@ interface PropertyOperations {
 }
 
 interface RuleOpsDbTypeData {
-  boolean: any;
-  date: any;
-  email: any;
-  float: any;
-  integer: any;
-  phoneNumber: any;
-  string: any;
-  url: any;
+  boolean: PropertyOperations[];
+  date: PropertyOperations[];
+  email: PropertyOperations[];
+  float: PropertyOperations[];
+  integer: PropertyOperations[];
+  phoneNumber: PropertyOperations[];
+  string: PropertyOperations[];
+  url: PropertyOperations[];
   [key: string]: any;
 }
 

--- a/data/property-ops-dictionary--postgres.json
+++ b/data/property-ops-dictionary--postgres.json
@@ -1,0 +1,347 @@
+{
+  "boolean": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    }
+  ],
+  "date": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "gt",
+      "description": "is after"
+    },
+    {
+      "op": "lt",
+      "description": "is before"
+    },
+    {
+      "op": "gte",
+      "description": "is on or after"
+    },
+    {
+      "op": "lte",
+      "description": "is on or before"
+    },
+    {
+      "op": "relative_gt",
+      "description": "is in the past"
+    },
+    {
+      "op": "relative_lt",
+      "description": "is in the future"
+    }
+  ],
+  "email": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    },
+    {
+      "op": "iLike",
+      "description": "is like (case insensitive)"
+    },
+    {
+      "op": "notILike",
+      "description": "is not like (case insensitive)"
+    }
+  ],
+  "float": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "gt",
+      "description": "is greater than"
+    },
+    {
+      "op": "lt",
+      "description": "is less than"
+    },
+    {
+      "op": "gte",
+      "description": "is greater than or equal to"
+    },
+    {
+      "op": "lte",
+      "description": "is less than or equal to"
+    }
+  ],
+  "integer": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "gt",
+      "description": "is greater than"
+    },
+    {
+      "op": "lt",
+      "description": "is less than"
+    },
+    {
+      "op": "gte",
+      "description": "is greater than or equal to"
+    },
+    {
+      "op": "lte",
+      "description": "is less than or equal to"
+    }
+  ],
+  "phoneNumber": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    },
+    {
+      "op": "iLike",
+      "description": "is like (case insensitive)"
+    },
+    {
+      "op": "notILike",
+      "description": "is not like (case insensitive)"
+    }
+  ],
+  "string": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    },
+    {
+      "op": "iLike",
+      "description": "is like (case insensitive)"
+    },
+    {
+      "op": "notILike",
+      "description": "is not like (case insensitive)"
+    }
+  ],
+  "url": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    },
+    {
+      "op": "iLike",
+      "description": "is like (case insensitive)"
+    },
+    {
+      "op": "notILike",
+      "description": "is not like (case insensitive)"
+    }
+  ],
+  "_relativeMatchUnits": [
+    "days",
+    "weeks",
+    "months",
+    "quarters",
+    "years"
+  ],
+  "_convenientRules": {
+    "exists": {
+      "operation": {
+        "op": "ne"
+      },
+      "match": "null"
+    },
+    "notExists": {
+      "operation": {
+        "op": "eq"
+      },
+      "match": "null"
+    },
+    "relative_gt": {
+      "operation": {
+        "op": "gt"
+      },
+      "relativeMatchDirection": "subtract"
+    },
+    "relative_lt": {
+      "operation": {
+        "op": "lt"
+      },
+      "relativeMatchDirection": "add"
+    }
+  }
+}

--- a/data/property-ops-dictionary--sqlite.json
+++ b/data/property-ops-dictionary--sqlite.json
@@ -1,0 +1,315 @@
+{
+  "boolean": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    }
+  ],
+  "date": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "gt",
+      "description": "is after"
+    },
+    {
+      "op": "lt",
+      "description": "is before"
+    },
+    {
+      "op": "gte",
+      "description": "is on or after"
+    },
+    {
+      "op": "lte",
+      "description": "is on or before"
+    },
+    {
+      "op": "relative_gt",
+      "description": "is in the past"
+    },
+    {
+      "op": "relative_lt",
+      "description": "is in the future"
+    }
+  ],
+  "email": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    }
+  ],
+  "float": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "gt",
+      "description": "is greater than"
+    },
+    {
+      "op": "lt",
+      "description": "is less than"
+    },
+    {
+      "op": "gte",
+      "description": "is greater than or equal to"
+    },
+    {
+      "op": "lte",
+      "description": "is less than or equal to"
+    }
+  ],
+  "integer": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "gt",
+      "description": "is greater than"
+    },
+    {
+      "op": "lt",
+      "description": "is less than"
+    },
+    {
+      "op": "gte",
+      "description": "is greater than or equal to"
+    },
+    {
+      "op": "lte",
+      "description": "is less than or equal to"
+    }
+  ],
+  "phoneNumber": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    }
+  ],
+  "string": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    }
+  ],
+  "url": [
+    {
+      "op": "exists",
+      "description": "exists with any value"
+    },
+    {
+      "op": "notExists",
+      "description": "does not exist"
+    },
+    {
+      "op": "eq",
+      "description": "is equal to"
+    },
+    {
+      "op": "ne",
+      "description": "is not equal to"
+    },
+    {
+      "op": "like",
+      "description": "is like (case sensitive)"
+    },
+    {
+      "op": "notLike",
+      "description": "is not like (case sensitive)"
+    },
+    {
+      "op": "startsWith",
+      "description": "starts with"
+    },
+    {
+      "op": "endsWith",
+      "description": "ends with"
+    },
+    {
+      "op": "substring",
+      "description": "includes the string"
+    }
+  ],
+  "_relativeMatchUnits": [
+    "days",
+    "weeks",
+    "months",
+    "quarters",
+    "years"
+  ],
+  "_convenientRules": {
+    "exists": {
+      "operation": {
+        "op": "ne"
+      },
+      "match": "null"
+    },
+    "notExists": {
+      "operation": {
+        "op": "eq"
+      },
+      "match": "null"
+    },
+    "relative_gt": {
+      "operation": {
+        "op": "gt"
+      },
+      "relativeMatchDirection": "subtract"
+    },
+    "relative_lt": {
+      "operation": {
+        "op": "lt"
+      },
+      "relativeMatchDirection": "add"
+    }
+  }
+}

--- a/pages/docs/[section]/index.tsx
+++ b/pages/docs/[section]/index.tsx
@@ -5,15 +5,12 @@ import {
   TableOfContents,
   capitalize,
 } from "../../../components/docs/tableOfContents";
-import HavingProblems from "../../../components/docs/havingProblems";
-import DocImage from "../../../components/docs/image";
+import * as components from "../../../components/docs";
 import {
   loadEntries,
   loadMdxFile,
   getStaticMdxPaths,
 } from "../../../utils/mdxUtils";
-
-const components = { HavingProblems, Image: DocImage };
 
 export default function DocPage({ pageProps }) {
   const { source, frontMatter, docs, path } = pageProps;

--- a/pages/docs/guides/create-groups.mdx
+++ b/pages/docs/guides/create-groups.mdx
@@ -5,13 +5,25 @@ section: "guides"
 pullQuote: "Now that you've created Profiles and Profile Properties, the next step is to create Groups. Groups are a segment or cohort of Profiles."
 ---
 
-Now that you've created Profiles and Profile Properties, the next step is to create Groups. Groups are a segment or cohort of Profiles. You can have `Calculated Groups` and `Manual Groups`.
+Now that you've created Profiles and Profile Properties, the next step is to create Groups. Groups are a segment or cohort of Profiles. You can have _Calculated Groups_ and _Manual Groups_.
 
 ## Calculated Groups
 
-`Calculated Groups` add and remove Profiles automatically based on Group Rules that you define. Here are a few different examples of `Calculated Groups` and their rules:
+Calculated Groups add and remove Profiles automatically based on Group Rules that you define. Each Rule has several options for logically determining if a profile belongs in the group. Those options are listed below, followed by a few examples.
 
-### Example: Repeat Purchasers
+### Rule Operation Options
+
+Each Rule has an operator — a logical statement to filter profiles. A profile must match every Rule to be included in the Group.
+
+Available operations depends on both the _type_ of Property and the underlying Grouparoo database (SQLite vs. Postgres). See below for a list of rules. (If in doubt, choose Postgres.)
+
+<RuleOpsTable />
+
+### Examples
+
+Here are a few different examples of Calculated Groups and their rules:
+
+#### Example: Repeat Purchasers
 
 Group Rules:
 
@@ -27,7 +39,7 @@ Group Rules:
   height={414}
 />
 
-### Example: High-Value & Abandoned Cart Recently
+#### Example: High-Value & Abandoned Cart Recently
 
 Group Rules:
 
@@ -44,7 +56,7 @@ Group Rules:
   height={414}
 />
 
-### Example: High-Value Xhosa Speakers
+#### Example: High-Value Xhosa Speakers
 
 Group Rules:
 

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -179,6 +179,18 @@ hr {
 
 // -- Documentation --
 
-.documentationPage li {
-  margin-bottom: 1rem; // matches <p>
+.documentationPage {
+  li {
+    margin-bottom: 1rem; // matches <p>
+  }
+
+  .nav-tabs {
+    border-bottom: none;
+  }
+
+  .tab-content {
+    background-color: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: 0.25rem;
+  }
 }


### PR DESCRIPTION
This takes the JSON output from grouparoo/grouparoo#1241 and presents it as a tabbed series of tables to represent the operations available depending on the type of property and underlying Grouparoo database.

It assumes there is some mechanism in place for updating these two new files in the `data` directory. [This is a manual process for now](https://github.com/grouparoo/grouparoo/pull/1241#pullrequestreview-578840071).

I wanted to do more with this but decided to wrap it just to get it out the door so I can move on to reorganizing the docs as a whole. In particular:

- I kept the styling simple just to look presentable/legible.
- I wanted to add anchors to headings so we could link directly to them. I ran into some trouble. I will explore as a separate task during docs cleanup.
