### PR TITLE
Do not use next/image for animated gifs

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -45,8 +45,8 @@ function LogoAndSocialLinks({ router }) {
 
 function EditThisPage({ router }) {
   const urlBase = "https://github.com/grouparoo/www.grouparoo.com/tree/master";
-  const docsPageMatch = router.pathname.match(/^\/docs\/(.*)/);
-  const blogPageMatch = router.pathname.match(/^\/blog\/(.*)/);
+  const docsPageMatch = router.asPath.match(/^\/docs\/(.*)/);
+  const blogPageMatch = router.asPath.match(/^\/blog\/(.*)/);
 
   if (docsPageMatch) {
     return (

--- a/pages/blog/gifit.mdx
+++ b/pages/blog/gifit.mdx
@@ -7,12 +7,15 @@ image: "gifit/screenshot.png"
 tags: [engineering, notes]
 ---
 
-<Image
+<img
   alt="Grouparoo gif example of changing destination groups"
-  src="gifit/screenshot.gif"
-  width={766}
-  height={550}
+  src="/posts/gifit/screenshot.gif"
+  width="766"
+  height="550"
 />
+
+<br />
+<br />
 
 When building Grouparoo, the Grouparoo team often shares screen recordings of our work with each other. In many cases, the tools we are using (like Github, until recently anyway) could only embed image content into READMEs and Pull Requests. That meant that the humble animated gif was often the best way to share a video. Here is my personal script called `gifit` which uses the open source `ffmpeg` and `gifsicle` tools to make it super easy to convert any video file into an easy-to-share gif!
 


### PR DESCRIPTION
* Do not use next/image for animated gifs - it does crazy things trying to automatically resize and is slow and ends up with a much bigger filesize than it started with
* Fix router matches in footer