### PR TITLE
Remove references to SCHEDULER

### DIFF
--- a/pages/docs/deployment/aws-and-k8s.mdx
+++ b/pages/docs/deployment/aws-and-k8s.mdx
@@ -106,8 +106,6 @@ spec:
               value: "false"
             - name: WORKERS
               value: "10"
-            - name: SCHEDULER
-              value: "true"
             - name: REDIS_URL
               value: "redis://grouparoo-redis.xxx.ng.0001.use1.cache.amazonaws.com:6379/0"
             - name: DATABASE_URL
@@ -143,8 +141,6 @@ spec:
               value: "true"
             - name: WORKERS
               value: "0"
-            - name: SCHEDULER
-              value: "false"
             - name: REDIS_URL
               value: "redis://grouparoo-redis.xxx.ng.0001.use1.cache.amazonaws.com:6379/0"
             - name: DATABASE_URL

--- a/pages/docs/deployment/docker.mdx
+++ b/pages/docs/deployment/docker.mdx
@@ -48,7 +48,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       DATABASE_URL: postgresql://postgres:password@db:5432/grouparoo_docker
       WEB_SERVER: "true"
-      SCHEDULER: "false"
       WORKERS: 0
     depends_on:
       - db
@@ -63,7 +62,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       DATABASE_URL: postgresql://postgres:password@db:5432/grouparoo_docker
       WEB_SERVER: "false"
-      SCHEDULER: "true"
       WORKERS: 10
     depends_on:
       - db

--- a/pages/docs/deployment/heroku.mdx
+++ b/pages/docs/deployment/heroku.mdx
@@ -19,8 +19,8 @@ An example project can be found at https://github.com/grouparoo/app-example. You
 
 ```bash
 # in Procfile
-web:    WEB_SERVER=true  SCHEDULER=false WORKERS=0  cd node_modules/@grouparoo/core && ./bin/start
-worker: WEB_SERVER=false SCHEDULER=true  WORKERS=10 cd node_modules/@grouparoo/core && ./bin/start
+web:    WEB_SERVER=true  WORKERS=0  cd node_modules/@grouparoo/core && ./bin/start
+worker: WEB_SERVER=false WORKERS=10 cd node_modules/@grouparoo/core && ./bin/start
 ```
 
 2. Add the Heroku add-on `heroku-postgres` via `heroku addons:create heroku-postgresql:<PLAN_NAME>`. Learn more about the plan options here: https://devcenter.heroku.com/articles/heroku-postgresql. This add-on will set the Environment Variable `DATABASE_URL` which Grouparoo will automatically use.

--- a/pages/docs/installation/docker.mdx
+++ b/pages/docs/installation/docker.mdx
@@ -30,7 +30,6 @@ ENV PORT=3000
 ENV WEB_URL=https://grouparoo.company.com:$PORT
 ENV WEB_SERVER="true"
 ENV SERVER_TOKEN="change-me"
-ENV SCHEDULER="true"
 ENV WORKERS=1
 ENV REDIS_URL="redis://redis:6379/0"
 ENV DATABASE_URL="postgresql://postgres:password@db:5432/grouparoo_docker"

--- a/pages/docs/installation/node.mdx
+++ b/pages/docs/installation/node.mdx
@@ -136,7 +136,6 @@ Grouparoo is configured by environment variables. These environment variables te
 PORT=3000
 WEB_URL=http://localhost:3000
 WEB_SERVER=true
-SCHEDULER=true
 WORKERS=1
 REDIS_URL="redis://localhost:6379/0"
 DATABASE_URL="postgresql://localhost:5432/grouparoo_development"

--- a/pages/docs/support/environment.mdx
+++ b/pages/docs/support/environment.mdx
@@ -17,7 +17,6 @@ The Grouparoo application is configured primarily by setting environment variabl
 The following options configure if Grouparoo should enable the server and workers for this instance. When deploying, you will likely want some "api" servers and some "worker" servers, which can all be configured with these environment variables.
 
 - `WEB_SERVER=true`
-- `SCHEDULER=true`
 - `WORKERS=1`
 
 **Logging**
@@ -94,7 +93,6 @@ PORT=3000
 WEB_URL=http://localhost:3000
 
 WEB_SERVER=true
-SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=my-serer-token
 


### PR DESCRIPTION
This is to support changes in grouparoo/grouparoo#1314.

⚠️ Note that this could cause an issue for anyone who deploys between merging this and releasing the next core version (the one that will have this adjustment).