### PR TITLE
Make font size on `/docs` smaller

### DIFF
--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -169,7 +169,7 @@ hr {
 // -- Docs --
 
 .documentationPage {
-  font-family: Helvetica, Arial, sans-serif;
+  font-size: 15px;
 
   h1 a,
   h2 a,
@@ -206,11 +206,6 @@ hr {
     border-radius: 0.25rem;
     margin-bottom: 1rem;
   }
-}
-
-.documentationHeader {
-  font-family: "Courier New", Courier, monospace;
-  color: $grouparoo-dark-gray;
 }
 
 .docsTableOfContents {


### PR DESCRIPTION
Our default font size is very big (18px).  This PR drops `/docs` pages down to 15px
<img width="1540" alt="Screen Shot 2021-02-18 at 5 44 23 PM" src="https://user-images.githubusercontent.com/303226/108445287-faefe100-7210-11eb-8dd5-5098fb1e1dc3.png">
<img width="1540" alt="Screen Shot 2021-02-18 at 5 44 36 PM" src="https://user-images.githubusercontent.com/303226/108445297-fe836800-7210-11eb-9569-a311baaad343.png">

