### PR TITLE
Nav get-started button to match index get-started button

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -40,7 +40,7 @@ export default function Navigation() {
 
               <Button
                 variant="primary"
-                href="/docs"
+                href="/docs/getting-started"
                 size="sm"
                 style={{ marginTop: 7, marginBottom: 20 }}
               >


### PR DESCRIPTION
the `get started` button on the homepage was updated to point to `/docs/getting-started`, but the `get started` button in the nav was still pointing to `/docs`.  This PR fixes that.