### PR TITLE
Fix install command

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -16,7 +16,7 @@ Assuming you have Node.js (v12+) installed, all you have to do to get started is
 
 ```bash
 # in a new directory
-npm grouparoo install -g
+npm install -g grouparoo
 grouparoo init .
 grouparoo start
 ```

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -168,7 +168,7 @@ export default function IndexPage({ pageProps }) {
                 icon="npm"
                 code={
                   <>
-                    {`$`} npm grouparoo install -g
+                    {`$`} npm install -g grouparoo
                     <br />
                     {`$`} grouparoo init .
                     <br />


### PR DESCRIPTION
It's `npm install -g grouparoo`!

Closes https://github.com/grouparoo/grouparoo/issues/1346