### PR TITLE
Release Notes pages always call hooks the same number of times

### DIFF
--- a/pages/whats-new/[note].tsx
+++ b/pages/whats-new/[note].tsx
@@ -1,15 +1,107 @@
-import ReleaseIndex from "./index";
-import { getReleasePaths, getReleaseNote } from "../../utils/releaseNotes";
+import Head from "next/head";
+import Link from "next/link";
+import { Container, Row, Col } from "react-bootstrap";
+import hydrate from "next-mdx-remote/hydrate";
+import {
+  ReleaseNote,
+  getReleaseNote,
+  getReleasePaths,
+} from "../../utils/releaseNotes";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { releaseBadges, releaseDate, components } from "./index";
 
-export default function Note({ pageProps }) {
-  return ReleaseIndex({ pageProps });
+export default function ReleaseNotePage({ pageProps }) {
+  const feature: ReleaseNote = pageProps.feature;
+  const title = `Grouparoo: What's New - ${feature.title}`;
+  const content = hydrate(feature.source, { components: components });
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <link
+          rel="canonical"
+          href={`https://www.grouparoo.com/whats-new${
+            feature ? `/${feature.slug}` : ""
+          }`}
+        />
+
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@grouparoo" />
+        <meta name="twitter:creator" content="@grouparoo" />
+        <meta
+          property="og:url"
+          content={`https://www.grouparoo.com/whats-new/${feature.slug}`}
+        />
+        <meta property="og:title" content={feature.title} />
+        {feature.description ? (
+          <meta property="og:description" content={feature.description} />
+        ) : null}
+        {feature.image ? (
+          <meta property="og:image" content={feature.image} />
+        ) : null}
+      </Head>
+
+      <Container className="releasePage">
+        <Row>
+          <Col md={3} lg={2} className={"d-none"}>
+            {releaseBadges(feature.tags)}
+
+            <br />
+
+            {releaseDate(feature.date)}
+          </Col>
+          <Col>
+            <Row>
+              <Col>
+                <h1 style={{ paddingBottom: 0 }}>
+                  {feature.title}
+                  <a id={feature.slug} />
+                </h1>
+              </Col>
+              <Col style={{ textAlign: "right" }} xs={2}>
+                {feature.github && (
+                  <Link href={feature.github}>
+                    <a
+                      style={{ paddingLeft: 10 }}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <FontAwesomeIcon icon={["fab", "github"]} size="xs" />
+                    </a>
+                  </Link>
+                )}
+              </Col>
+            </Row>
+
+            <div style={{ paddingBottom: 10 }} className={"d-xs-none"}>
+              {releaseBadges(feature.tags)} {releaseDate(feature.date)}
+            </div>
+
+            <div>{content}</div>
+
+            {feature.blog && (
+              <Link href={`/blog/${feature.blog}`}>
+                <a>See more</a>
+              </Link>
+            )}
+            <div style={{ marginTop: 32, marginBottom: 32 }} />
+          </Col>
+        </Row>
+
+        <hr />
+
+        <Link href="/whats-new">
+          <a>See all Updates</a>
+        </Link>
+      </Container>
+    </>
+  );
 }
 
 export async function getStaticProps(ctx) {
-  const slug = ctx.params.note;
-  const note = await getReleaseNote(slug);
-
-  return { props: { feature: note } };
+  const feature = await getReleaseNote(ctx.params.note);
+  return { props: { feature } };
 }
 
 export async function getStaticPaths() {

--- a/pages/whats-new/index.tsx
+++ b/pages/whats-new/index.tsx
@@ -15,10 +15,6 @@ export default function ReleaseIndex({ pageProps }) {
   let notes: ReleaseNote[] = pageProps.notes;
   const { limit, offset, total } = pageProps;
 
-  const contents = notes
-    ? notes.map((note) => hydrate(note.source, { components: components }))
-    : [];
-
   return (
     <>
       <Head>
@@ -46,10 +42,11 @@ export default function ReleaseIndex({ pageProps }) {
         {notes
           ? notes.map((note, idx) => {
               const { tags, date, title, blog, slug, github } = note;
+              const content = hydrate(note.source, { components: components });
               const ago = releaseDate(date);
               const badges = releaseBadges(tags);
 
-              if (!title) return null;
+              if (!title) return null; // do not render placeholder notes
 
               return (
                 <Row key={`note-${idx}`}>
@@ -58,7 +55,7 @@ export default function ReleaseIndex({ pageProps }) {
                     <br />
                     {ago}
                   </Col>
-                  <Col>
+                  <Col md={9} lg={10}>
                     <Row>
                       <Col>
                         <h4 style={{ paddingBottom: 0 }}>
@@ -66,6 +63,7 @@ export default function ReleaseIndex({ pageProps }) {
                           <a id={slug} />
                         </h4>
                       </Col>
+
                       <Col style={{ textAlign: "right" }} xs={2}>
                         {github && (
                           <Link href={github}>
@@ -92,12 +90,15 @@ export default function ReleaseIndex({ pageProps }) {
                     <div style={{ paddingBottom: 10 }} className={"d-md-none"}>
                       {badges} {ago}
                     </div>
-                    <div>{contents[idx]}</div>
+
+                    <div>{content}</div>
+
                     {blog && (
                       <Link href={`/blog/${blog}`}>
                         <a>See more</a>
                       </Link>
                     )}
+
                     <hr style={{ marginTop: 32, marginBottom: 32 }} />
                   </Col>
                 </Row>

--- a/pages/whats-new/index.tsx
+++ b/pages/whats-new/index.tsx
@@ -15,9 +15,9 @@ export default function ReleaseIndex({ pageProps }) {
   let notes: ReleaseNote[] = pageProps.notes;
   const { limit, offset, total } = pageProps;
 
-  const contents = notes.map((note) =>
-    hydrate(note.source, { components: components })
-  );
+  const contents = notes
+    ? notes.map((note) => hydrate(note.source, { components: components }))
+    : [];
 
   return (
     <>

--- a/pages/whats-new/index.tsx
+++ b/pages/whats-new/index.tsx
@@ -9,143 +9,21 @@ import Moment from "react-moment";
 import BlogImage from "../../components/blog/image";
 import { PaginationHelper } from "../../components/paginationHelper";
 
-const components = { Image: BlogImage };
-
-function releaseNote(note: ReleaseNote, idx: number) {
-  const isFeature = idx < 0;
-
-  const { source, tags, date, title, blog, slug } = note;
-  const content = hydrate(source, { components: components });
-  const ago = releaseDate(date);
-  const badges = releaseBadges(tags);
-  const header = releaseHeader(note, isFeature);
-
-  const leftClassName = isFeature ? "d-none" : "d-none d-md-block";
-  const rightClassName = isFeature ? "d-xs-none" : "d-md-none";
-  const Separator = isFeature ? "div" : "hr";
-
-  return (
-    <Row key={`releaseNote-${idx}`}>
-      <Col md={3} lg={2} className={leftClassName}>
-        {badges}
-        <br />
-        {ago}
-      </Col>
-      <Col>
-        {header}
-        <div style={{ paddingBottom: 10 }} className={rightClassName}>
-          {badges} {ago}
-        </div>
-        <div>{content}</div>
-        {blog && (
-          <Link href={`/blog/${blog}`}>
-            <a>See more</a>
-          </Link>
-        )}
-        <Separator style={{ marginTop: 32, marginBottom: 32 }} />
-      </Col>
-    </Row>
-  );
-}
-
-function featureNote(note: ReleaseNote) {
-  return releaseNote(note, -1);
-}
-
-function releaseHeader(note: ReleaseNote, isFeature: boolean) {
-  const Header = isFeature ? "h1" : "h4";
-  const { github, slug, title } = note;
-  return (
-    <>
-      <Row>
-        <Col>
-          <Header style={{ paddingBottom: 0 }}>
-            {title}
-            <a id={slug} />
-          </Header>
-        </Col>
-        <Col style={{ textAlign: "right" }} xs={2}>
-          {github && (
-            <Link href={github}>
-              <a style={{ paddingLeft: 10 }} target="_blank" rel="noreferrer">
-                <FontAwesomeIcon icon={["fab", "github"]} size="xs" />
-              </a>
-            </Link>
-          )}
-          {!isFeature && (
-            <Link href={`/whats-new/${slug}`}>
-              <a style={{ paddingLeft: 10 }}>
-                <FontAwesomeIcon icon={["fas", "link"]} size="xs" />
-              </a>
-            </Link>
-          )}
-        </Col>
-      </Row>
-    </>
-  );
-}
-
-function getHeader(feature: ReleaseNote) {
-  if (!feature) {
-    return <h1 style={{ paddingBottom: 30 }}>What's New</h1>;
-  }
-
-  return (
-    <>
-      {featureNote(feature)}
-      <hr />
-      <Link href="/whats-new">
-        <a>See all Updates</a>
-      </Link>
-    </>
-  );
-}
-
-function getSocial(feature: ReleaseNote) {
-  if (!feature) {
-    return null;
-  }
-
-  const url = `https://www.grouparoo.com/whats-new/${feature.slug}`;
-  return (
-    <>
-      <meta name="twitter:card" content="summary" />
-      <meta name="twitter:site" content="@grouparoo" />
-      <meta name="twitter:creator" content="@grouparoo" />
-      <meta property="og:url" content={url} />
-      <meta property="og:title" content={feature.title} />
-      {feature.description ? (
-        <meta property="og:description" content={feature.description} />
-      ) : null}
-      {feature.image ? (
-        <meta property="og:image" content={feature.image} />
-      ) : null}
-    </>
-  );
-}
+export const components = { Image: BlogImage };
 
 export default function ReleaseIndex({ pageProps }) {
   let notes: ReleaseNote[] = pageProps.notes;
-  let feature: ReleaseNote = pageProps.feature;
   const { limit, offset, total } = pageProps;
 
-  let headerComponent = getHeader(feature);
-  let socialComponent = getSocial(feature);
-  let title = "Grouparoo: What's New";
-  if (feature) {
-    title += ` - ${feature.title}`;
-  }
+  const contents = notes.map((note) =>
+    hydrate(note.source, { components: components })
+  );
+
   return (
     <>
       <Head>
-        <title>{title}</title>
-        <link
-          rel="canonical"
-          href={`https://www.grouparoo.com/whats-new${
-            feature ? `/${feature.slug}` : ""
-          }`}
-        />
-
+        <title>Grouparoo: What's New</title>
+        <link rel="canonical" href={`https://www.grouparoo.com/whats-new`} />
         <link
           rel="alternate"
           title="JSON Feed: Grouparoo What's New"
@@ -158,34 +36,85 @@ export default function ReleaseIndex({ pageProps }) {
           type="application/rss+xml"
           href="https://www.grouparoo.com/feeds/whatsnew.xml"
         />
-
-        {socialComponent}
       </Head>
 
       <Container className="releasePage">
-        {headerComponent}
-        {feature ? null : notes && notes.length > 0 ? (
-          notes.map((note, idx) => releaseNote(note, idx))
-        ) : (
-          <p>No notes found</p>
-        )}
+        <h1 style={{ paddingBottom: 30 }}>What's New</h1>
 
-        {feature ? null : (
-          <Row>
-            <Col md={3} lg={2} />
-            <Col>
-              <PaginationHelper
-                baseUrl={`/whats-new/page`}
-                total={total}
-                limit={limit}
-                offset={offset}
-              />
-            </Col>
-          </Row>
-        )}
+        {!notes || notes.length === 0 ? <p>No notes found</p> : null}
+
+        {notes
+          ? notes.map((note, idx) => {
+              const { tags, date, title, blog, slug, github } = note;
+              const ago = releaseDate(date);
+              const badges = releaseBadges(tags);
+
+              return (
+                <Row key={`note-${idx}`}>
+                  <Col md={3} lg={2} className={"d-none d-md-block"}>
+                    {badges}
+                    <br />
+                    {ago}
+                  </Col>
+                  <Col>
+                    <Row>
+                      <Col>
+                        <h4 style={{ paddingBottom: 0 }}>
+                          {title}
+                          <a id={slug} />
+                        </h4>
+                      </Col>
+                      <Col style={{ textAlign: "right" }} xs={2}>
+                        {github && (
+                          <Link href={github}>
+                            <a
+                              style={{ paddingLeft: 10 }}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              <FontAwesomeIcon
+                                icon={["fab", "github"]}
+                                size="xs"
+                              />
+                            </a>
+                          </Link>
+                        )}
+                        <Link href={`/whats-new/${slug}`}>
+                          <a style={{ paddingLeft: 10 }}>
+                            <FontAwesomeIcon icon={["fas", "link"]} size="xs" />
+                          </a>
+                        </Link>
+                      </Col>
+                    </Row>
+
+                    <div style={{ paddingBottom: 10 }} className={"d-md-none"}>
+                      {badges} {ago}
+                    </div>
+                    <div>{contents[idx]}</div>
+                    {blog && (
+                      <Link href={`/blog/${blog}`}>
+                        <a>See more</a>
+                      </Link>
+                    )}
+                    <hr style={{ marginTop: 32, marginBottom: 32 }} />
+                  </Col>
+                </Row>
+              );
+            })
+          : null}
+
+        <Row>
+          <Col md={3} lg={2} />
+          <Col>
+            <PaginationHelper
+              baseUrl={`/whats-new/page`}
+              total={total}
+              limit={limit}
+              offset={offset}
+            />
+          </Col>
+        </Row>
       </Container>
-
-      <br />
     </>
   );
 }
@@ -196,21 +125,13 @@ export async function getStaticProps(ctx) {
   return { props: { notes, limit, offset, total } };
 }
 
-function releaseDate(date: string) {
-  return (
-    <span className="metadata">
-      <Moment fromNow>{date}</Moment>
-    </span>
-  );
-}
-
-const badgeTypes = {
+export const badgeTypes = {
   new: "primary",
   improvement: "success",
   fix: "warning",
 };
 
-function releaseBadges(tags: string[]) {
+export function releaseBadges(tags: string[]) {
   return (
     <span>
       {(tags || []).map((tag, idx) => (
@@ -221,6 +142,14 @@ function releaseBadges(tags: string[]) {
           &nbsp;
         </Fragment>
       ))}
+    </span>
+  );
+}
+
+export function releaseDate(date: string) {
+  return (
+    <span className="metadata">
+      <Moment fromNow>{date}</Moment>
     </span>
   );
 }

--- a/pages/whats-new/index.tsx
+++ b/pages/whats-new/index.tsx
@@ -49,6 +49,8 @@ export default function ReleaseIndex({ pageProps }) {
               const ago = releaseDate(date);
               const badges = releaseBadges(tags);
 
+              if (!title) return null;
+
               return (
                 <Row key={`note-${idx}`}>
                   <Col md={3} lg={2} className={"d-none d-md-block"}>

--- a/utils/releaseNotes.ts
+++ b/utils/releaseNotes.ts
@@ -61,6 +61,29 @@ export async function getReleaseNotes(pageNumber: number = 1, limit = LIMIT) {
     })
   );
 
+  // we need the number of 'hydrate' calls in the list view to match exactly on all pages
+  while (paginatedNotes.length < limit) {
+    paginatedNotes.push({
+      title: null,
+      slug: null,
+      date: null,
+      description: null,
+      source: {
+        compiledSource:
+          "function MDXContent() { return null }" +
+          "MDXContent.isMDXComponent = false;",
+        renderedOutput: null,
+        scope: {},
+      },
+      image: null,
+      tags: [],
+      github: null,
+      blog: null,
+    });
+  }
+
+  console.log(paginatedNotes[0]);
+
   return { notes: paginatedNotes, limit, offset, total: notes.length };
 }
 

--- a/utils/releaseNotes.ts
+++ b/utils/releaseNotes.ts
@@ -82,8 +82,6 @@ export async function getReleaseNotes(pageNumber: number = 1, limit = LIMIT) {
     });
   }
 
-  console.log(paginatedNotes[0]);
-
   return { notes: paginatedNotes, limit, offset, total: notes.length };
 }
 


### PR DESCRIPTION
Regardless of how many entries are on each paginated page, the number of calls to `hydrate()` needs to be the same between paginated pages.  Otherwise, React thinks that something is wrong.

To accomplish this, we always return an 'empty' MDX object we can hydrate, and then late choose not to render it on the page.

This PR also splits up the logic between the list view and details view of a release note to keep things simple. 

---
Prevents errors like this: 

<img width="1401" alt="Screen Shot 2021-03-01 at 8 29 17 PM" src="https://user-images.githubusercontent.com/303226/109597304-d0354080-7acc-11eb-8fda-aa362278bd34.png">
