### PR TITLE
Add details for common spec helper methods

### DIFF
--- a/pages/docs/running/testing.mdx
+++ b/pages/docs/running/testing.mdx
@@ -101,3 +101,53 @@ describe("snapshot", () => {
 ## Testing Notes
 
 - Unless you specify in your `package.json` or `jest.config.js`, You'll need to use magic comments to let Jest know that we are running a Node.js app (`@jest-environment node`)
+
+## Spec Helper API
+
+The spec helper makes a few helpful methods available to you. Here are the commonly-used methods and options:
+
+### `grouparooTestServer`
+
+Starts a test version of the Grouparoo server prior to running the specs and stops it after running the tests.
+
+Usage:
+
+```js
+const options = {
+  truncate: false,
+  enableTestPlugin: false,
+  resetSettings: false,
+  disableTestPluginImport: false,
+};
+helper.grouparooTestServer(options);
+```
+
+Options are passed as an object. Available options:
+
+- `truncate` (`boolean`): Truncates the database prior to starting the server. (Default: `false`)
+- `enableTestPlugin` (`boolean`): Mocks a plugin. (Default: `false`)
+- `resetSettings` (`boolean`): Sets all settings back to their default values _after_ starting the server. (Default: `false`)
+- `disableTestPluginImport` (`boolean`): Disables the ability for the mocked plugin to import files. Must be used in conjunction with `enableTestPlugin`. (Default: `false`)
+
+### `getProfile`
+
+Retrieves a profile from a series of key-value pairs representing properties of that profile.
+
+Usage:
+
+```js
+const profile = await helper.getProfile({
+  user_id: 100,
+  email: "example@example.com",
+});
+```
+
+<Alert variant="warning">
+  <p className="mb-0">
+    ⚠️{" "}
+    <strong>
+      Note that the set of properties passed must include the bootstrapped
+      Property (the first Property created in Grouparoo).
+    </strong>
+  </p>
+</Alert>

--- a/pages/docs/running/testing.mdx
+++ b/pages/docs/running/testing.mdx
@@ -113,21 +113,14 @@ Starts a test version of the Grouparoo server prior to running the specs and sto
 Usage:
 
 ```js
-const options = {
-  truncate: false,
-  enableTestPlugin: false,
-  resetSettings: false,
-  disableTestPluginImport: false,
-};
-helper.grouparooTestServer(options);
+helper.grouparooTestServer();
 ```
 
-Options are passed as an object. Available options:
+Options may be passed to `grouparooTestServer` as an object. The main option of use to you is `truncate`, which tells the helper to truncate the database prior to running the specs.
 
-- `truncate` (`boolean`): Truncates the database prior to starting the server. (Default: `false`)
-- `enableTestPlugin` (`boolean`): Mocks a plugin. (Default: `false`)
-- `resetSettings` (`boolean`): Sets all settings back to their default values _after_ starting the server. (Default: `false`)
-- `disableTestPluginImport` (`boolean`): Disables the ability for the mocked plugin to import files. Must be used in conjunction with `enableTestPlugin`. (Default: `false`)
+```js
+helper.grouparooTestServer({ truncate: false });
+```
 
 ### `getProfile`
 


### PR DESCRIPTION
Add documentation for commonly-used spec helper methods for Grouparoo users.

⚠️ This corresponds with grouparoo/grouparoo#1419 and contains a bug that won't be fixed until the next release. (Currently `truncate` does so at the wrong time and causes errors with code config projects.

Concerns/notes:

- I didn't automate this because I felt like it was important to be selective about the information shared with those who will consume this page. Maybe eventually we want to share the whole spec helper API, but for now it seems like we could stick to the common and simple examples.
- Some of the options seem to be geared toward usage in core alone. I was on the fence about removing the plugin options.
- I don't think I have great language for the options here.

![Screen Shot 2021-03-03 at 3 02 22 PM](https://user-images.githubusercontent.com/5245089/109864940-769a5680-7c31-11eb-95b2-2ef73b65f503.png)
