### PR TITLE
Un-bold integration card names

### DIFF
--- a/components/home/integrationCard.tsx
+++ b/components/home/integrationCard.tsx
@@ -37,9 +37,7 @@ export default function IntegrationCard({
             slug={slug}
             name={name}
           />
-          <Card.Text>
-            <strong>{name}</strong>
-          </Card.Text>
+          <Card.Text>{name}</Card.Text>
 
           {type ? (
             <>


### PR DESCRIPTION
Un-bolding the name prevents wrapping the Grouparoo name on mobile

<img width="342" alt="Screen Shot 2021-03-08 at 2 58 44 PM" src="https://user-images.githubusercontent.com/303226/110393211-00c23080-801f-11eb-8eb3-765513537fa9.png">
