### PR TITLE
Store `utm_*` variables and send them with `/meet` requests

### DIFF
--- a/__tests__/integration/sessionStorage.ts
+++ b/__tests__/integration/sessionStorage.ts
@@ -34,4 +34,34 @@ describe("integration", () => {
     expect(await getSessionItem("prevPath")).toBe("/docs/config");
     expect(await getSessionItem("currentPath")).toBe("/meet");
   });
+
+  test("stores UTM_* tracking variables on any page", async () => {
+    await browser.get(
+      url +
+        `/docs?utm_source=test_source&utm_campaign=test_campaign&utm_medium=test_medium`
+    );
+
+    // change page without UTM variables
+    await browser.get(url + "/");
+
+    // the UTM variables are stored
+    expect(await getSessionItem("utm_source")).toBe("test_source");
+    expect(await getSessionItem("utm_campaign")).toBe("test_campaign");
+    expect(await getSessionItem("utm_medium")).toBe("test_medium");
+  });
+
+  test("will not replace original UTM_* tracking variables with new ones", async () => {
+    await browser.get(
+      url +
+        `/docs?utm_source=test_source&utm_campaign=test_campaign&utm_medium=test_medium`
+    );
+    await browser.get(
+      url +
+        `/integrations?utm_source=new_source&utm_campaign=new_campaign&utm_medium=new_medium`
+    );
+
+    expect(await getSessionItem("utm_source")).toBe("test_source");
+    expect(await getSessionItem("utm_campaign")).toBe("test_campaign");
+    expect(await getSessionItem("utm_medium")).toBe("test_medium");
+  });
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,6 @@ import "../components/icons"; // this is needed to load the library
 import Layout from "../components/layouts/main";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
-import { ParsedUrlQuery } from "querystring";
 
 export default function GrouparooWWW(props) {
   const { Component } = props;
@@ -27,22 +26,20 @@ export default function GrouparooWWW(props) {
     storage.setItem("prevPath", prevPath);
     storage.setItem("currentPath", globalThis.location.pathname);
 
-    ["utm_source", "utm_medium", "utm_campaign"].forEach((q) =>
-      storeQueryToSession(router.query, storage, q)
-    );
+    Object.keys(router.query)
+      .filter((k) => k.match(/^utm_*/))
+      .forEach((k) => {
+        const tmp = router.query[k];
+        const value = Array.isArray(tmp) ? tmp[0] : tmp;
+        storeQueryToSession(storage, k, value);
+      });
   }
 
   function scrollToTop() {
     globalThis.scrollTo(0, 0);
   }
 
-  function storeQueryToSession(
-    query: ParsedUrlQuery,
-    storage: Storage,
-    key: string
-  ) {
-    const tmp = query[key];
-    const value = Array.isArray(tmp) ? tmp[0] : tmp;
+  function storeQueryToSession(storage: Storage, key: string, value: string) {
     if (!value) return;
     const existing = storage.getItem(key);
     if (!existing) storage.setItem(key, value);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,33 +1,50 @@
 import "../scss/grouparoo.scss";
 import "../components/icons"; // this is needed to load the library
 import Layout from "../components/layouts/main";
-import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
 
 export default function GrouparooWWW(props) {
   const { Component } = props;
   const router = useRouter();
 
   useEffect(() => {
-    setCookies();
+    storeInSession();
 
     router.events.on("routeChangeComplete", scrollToTop);
 
     return () => {
       router.events.off("routeChangeComplete", scrollToTop);
     };
-  }, [router.asPath]);
+  }, [router.asPath, router.isReady]);
 
-  function setCookies() {
+  function storeInSession() {
     const storage = globalThis?.sessionStorage;
     if (!storage) return;
+
     const prevPath = storage.getItem("currentPath");
     storage.setItem("prevPath", prevPath);
     storage.setItem("currentPath", globalThis.location.pathname);
+
+    ["utm_source", "utm_medium", "utm_campaign"].forEach((q) =>
+      storeQueryToSession(router.query, storage, q)
+    );
   }
 
   function scrollToTop() {
     globalThis.scrollTo(0, 0);
+  }
+
+  function storeQueryToSession(
+    query: ParsedUrlQuery,
+    storage: Storage,
+    key: string
+  ) {
+    const tmp = query[key];
+    const value = Array.isArray(tmp) ? tmp[0] : tmp;
+    const existing = storage.getItem(key);
+    if (!existing && value) storage.setItem(key, value);
   }
 
   return (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,8 +43,9 @@ export default function GrouparooWWW(props) {
   ) {
     const tmp = query[key];
     const value = Array.isArray(tmp) ? tmp[0] : tmp;
+    if (!value) return;
     const existing = storage.getItem(key);
-    if (!existing && value) storage.setItem(key, value);
+    if (!existing) storage.setItem(key, value);
   }
 
   return (

--- a/pages/meet.tsx
+++ b/pages/meet.tsx
@@ -43,18 +43,32 @@ export default function Meet() {
   const onSubmit = async (data) => {
     setLoading(true);
 
+    // defaults
+    let source = "/meet";
+    let medium = "web";
     let campaign = globalThis?.document?.referrer;
-    const storage = globalThis?.sessionStorage;
-    if (storage) campaign = storage.getItem("prevPath");
 
-    data.source = "/meet";
-    data.medium = "web";
+    const storage = globalThis?.sessionStorage;
+    if (storage) {
+      source = storage.getItem("utm_source")
+        ? storage.getItem("utm_source")
+        : storage.getItem("prevPath")
+        ? storage.getItem("prevPath")
+        : source;
+      medium = storage.getItem("utm_medium")
+        ? storage.getItem("utm_medium")
+        : medium;
+      campaign = storage.getItem("utm_campaign")
+        ? storage.getItem("utm_campaign")
+        : campaign;
+    }
+
+    data.source = source;
+    data.medium = medium;
     data.campaign = campaign;
 
     const response = await execApi("post", `/api/v1/demo-request`, data);
-    if (response?.demoRequest) {
-      setRequested(true);
-    }
+    if (response?.demoRequest) setRequested(true);
     setLoading(false);
   };
 


### PR DESCRIPTION
We store `utm_*` query params (like `utm_campaign`, `utm_source` and `utm_medium`) in sessionStorage now.  We can use this data when we send data to the telemetry API, e.g.: when folks what to `/meet` us. 