### PR TITLE
update `validate/apply --local` description to support passing ids

### DIFF
--- a/data/cli-commands.json
+++ b/data/cli-commands.json
@@ -28,11 +28,10 @@
     "description": "Apply changes from code config",
     "example": "",
     "inputs": {
-      "local": {
+      "local [ids...]": {
         "default": false,
-        "description": "Disable external validation",
-        "letter": "l",
-        "flag": true
+        "description": "Disable external validation. You can optionally pass object IDs to only disable external validation for those specific config objects (`--local mailchimp salesforce`)",
+        "letter": "l"
       },
       "timestamps": {
         "default": false,

--- a/data/cli-commands.json
+++ b/data/cli-commands.json
@@ -232,11 +232,10 @@
     "description": "Validate your code config",
     "example": "",
     "inputs": {
-      "local": {
+      "local [ids...]": {
         "default": false,
-        "description": "Disable external validation",
-        "letter": "l",
-        "flag": true
+        "description": "Disable external validation. You can optionally pass object IDs to only disable external validation for those specific config objects (`--local mailchimp salesforce`)",
+        "letter": "l"
       },
       "timestamps": {
         "default": false,


### PR DESCRIPTION
As of https://github.com/grouparoo/grouparoo/pull/1701, the `--local` option now supports passing specific IDs

see in https://www-grouparoo-com-git-docs-selective-local-validation-grouparoo.vercel.app/docs/cli/config#validate