### PR TITLE
Replace `Nav.Link` with `div` in Header

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -251,21 +251,21 @@ export default function Navigation() {
                 </Container>
               </NavDropdown>
 
-              <Nav.Link>
+              <div className="nav-link">
                 <Link href="/pricing">
                   <a className="nav-link" role="button">
                     Pricing
                   </a>
                 </Link>
-              </Nav.Link>
+              </div>
 
-              <Nav.Link>
+              <div className="nav-link">
                 <Link href="/blog">
                   <a className="nav-link" role="button">
                     Blog
                   </a>
                 </Link>
-              </Nav.Link>
+              </div>
             </Nav>
             <a
               href="https://github.com/grouparoo/grouparoo"


### PR DESCRIPTION
Fixes a bug in which an `<a>` was inside an `<a>` tag (as that's what `Nav.Link` generates).  Since we wanted to keep the css property, and were manually making `<a>`'s ourself, this PR swaps in a div. 