### PR TITLE
`ImageInBrowserFrame` component

### DIFF
--- a/components/imageInBrowserFrame.tsx
+++ b/components/imageInBrowserFrame.tsx
@@ -1,0 +1,62 @@
+import Image from "./Image";
+
+export default function ImageInBrowserFrame({
+  src,
+  height,
+  width,
+  alt,
+}: {
+  src: string;
+  height: number;
+  width: number;
+  alt: string;
+}) {
+  const borderColor = "#cccccc";
+  const buttonBorderColor = "#dadada";
+  const thickness = 4;
+  const buttons = ["red", "yellow", "green"];
+
+  return (
+    <div
+      style={{
+        padding: "20px 0 0",
+        borderRadius: thickness,
+        borderBottom: `${thickness}px solid ${borderColor}`,
+        borderLeft: `${thickness}px solid ${borderColor}`,
+        borderRight: `${thickness}px solid ${borderColor}`,
+        background: `${borderColor}`,
+        display: "inline-block",
+        position: "relative",
+        lineHeight: 0,
+        filter: `drop-shadow(6px 6px 12px rgba(0,0,0,0.5))`,
+      }}
+    >
+      <div
+        style={{
+          display: "block",
+          height: 15,
+          position: "absolute",
+          top: 5,
+          left: 1,
+        }}
+      >
+        {buttons.map((button, idx) => (
+          <span
+            key={`button-${idx}`}
+            style={{
+              height: 8,
+              width: 8,
+              borderRadius: 8,
+              border: `1px solid ${buttonBorderColor}`,
+              float: "left",
+              margin: "0 0 0 4px",
+              backgroundColor: button,
+            }}
+          />
+        ))}
+      </div>
+
+      <Image src={src} width={width} height={height} alt={alt} />
+    </div>
+  );
+}

--- a/components/imageInBrowserFrame.tsx
+++ b/components/imageInBrowserFrame.tsx
@@ -14,6 +14,7 @@ export default function ImageInBrowserFrame({
   const borderColor = "#cccccc";
   const buttonBorderColor = "#dadada";
   const thickness = 4;
+  const sideThickness = 1;
   const buttons = ["red", "yellow", "green"];
 
   return (
@@ -23,8 +24,8 @@ export default function ImageInBrowserFrame({
         margin: 10,
         borderRadius: thickness,
         borderBottom: `${thickness}px solid ${borderColor}`,
-        borderLeft: `${thickness}px solid ${borderColor}`,
-        borderRight: `${thickness}px solid ${borderColor}`,
+        borderLeft: `${sideThickness}px solid ${borderColor}`,
+        borderRight: `${sideThickness}px solid ${borderColor}`,
         background: `${borderColor}`,
         display: "inline-block",
         position: "relative",

--- a/components/imageInBrowserFrame.tsx
+++ b/components/imageInBrowserFrame.tsx
@@ -12,10 +12,9 @@ export default function ImageInBrowserFrame({
   alt: string;
 }) {
   const borderColor = "#cccccc";
-  const buttonBorderColor = "#dadada";
   const thickness = 4;
   const sideThickness = 1;
-  const buttons = ["red", "yellow", "green"];
+  const buttons = ["#FF544D", "#FEB429", "#24C339"];
 
   return (
     <div
@@ -49,7 +48,6 @@ export default function ImageInBrowserFrame({
               height: 8,
               width: 8,
               borderRadius: 8,
-              border: `1px solid ${buttonBorderColor}`,
               float: "left",
               margin: "0 0 0 4px",
               backgroundColor: button,

--- a/components/imageInBrowserFrame.tsx
+++ b/components/imageInBrowserFrame.tsx
@@ -20,6 +20,7 @@ export default function ImageInBrowserFrame({
     <div
       style={{
         padding: "20px 0 0",
+        margin: 10,
         borderRadius: thickness,
         borderBottom: `${thickness}px solid ${borderColor}`,
         borderLeft: `${thickness}px solid ${borderColor}`,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,7 @@ import CustomerTestimonials from "../components/home/customerTestimonials";
 import { randomHomepagePlugins } from "../data/plugins";
 import { getReleaseNotes } from "../utils/releaseNotes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import ImageInBrowserFrame from "../components/imageInBrowserFrame";
 
 export default function IndexPage({ pageProps, setReleaseNote }) {
   const {
@@ -451,8 +452,7 @@ export default function IndexPage({ pageProps, setReleaseNote }) {
               </div>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-1.png"
                 alt="Grouparoo profile"
                 width={650}
@@ -471,8 +471,7 @@ export default function IndexPage({ pageProps, setReleaseNote }) {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-2.png"
                 alt="Grouparoo groups"
                 width={650}
@@ -490,8 +489,7 @@ export default function IndexPage({ pageProps, setReleaseNote }) {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-3.png"
                 alt="Grouparoo destination"
                 width={650}
@@ -513,8 +511,7 @@ export default function IndexPage({ pageProps, setReleaseNote }) {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-4.png"
                 alt="Data synced to destination"
                 width={650}

--- a/pages/integrations/[type]/[plugin].tsx
+++ b/pages/integrations/[type]/[plugin].tsx
@@ -9,6 +9,7 @@ import IntegrationsHead from "../../../components/home/integrationsHead";
 import GetStarted from "../../../components/home/getStarted";
 import BigArrow from "../../../components/bigArrow";
 import { PluginData, getUseCasePaths } from "../../../data/plugins";
+import ImageInBrowserFrame from "../../../components/imageInBrowserFrame";
 
 export default function IntegrationsPage({
   pageProps,
@@ -49,8 +50,7 @@ export default function IntegrationsPage({
                 <p>{screenshot.description}</p>
               </Col>
               <Col md={8}>
-                <Image
-                  className="productScreenshots border"
+                <ImageInBrowserFrame
                   src={screenshot.imageSrc}
                   alt={screenshot.imageAlt}
                   width={screenshot.imageWidth}
@@ -70,8 +70,7 @@ export default function IntegrationsPage({
                 <p>{screenshot.description}</p>
               </Col>
               <Col md={8} className="order-2 order-md-1">
-                <Image
-                  className="productScreenshots border"
+                <ImageInBrowserFrame
                   src={screenshot.imageSrc}
                   alt={screenshot.imageAlt}
                   width={screenshot.imageWidth}

--- a/pages/integrations/bigquery-to-salesforce.tsx
+++ b/pages/integrations/bigquery-to-salesforce.tsx
@@ -3,6 +3,7 @@ import Image from "../../components/Image";
 import IntegrationCard from "../../components/home/integrationCard";
 import SEO from "../../components/seo";
 import BigArrow from "../../components/bigArrow";
+import ImageInBrowserFrame from "../../components/imageInBrowserFrame";
 
 export default function BigQueryToSalesforce() {
   return (
@@ -176,8 +177,7 @@ export default function BigQueryToSalesforce() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/bigquery/add-bigquery-app.png"
                 alt="Grouparoo BigQuery settings"
                 width={742}
@@ -188,8 +188,7 @@ export default function BigQueryToSalesforce() {
           <br />
           <Row className="align-items-center">
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/bigquery/bigquery-table-mode.png"
                 alt="Grouparoo table source settings"
                 width={742}
@@ -221,8 +220,7 @@ export default function BigQueryToSalesforce() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/salesforce/grouparoo-to-salesforce.png"
                 alt="Map data to Salesforce"
                 width={742}

--- a/pages/integrations/postgres-to-hubspot.tsx
+++ b/pages/integrations/postgres-to-hubspot.tsx
@@ -3,6 +3,7 @@ import Image from "../../components/Image";
 import IntegrationCard from "../../components/home/integrationCard";
 import SEO from "../../components/seo";
 import BigArrow from "../../components/bigArrow";
+import ImageInBrowserFrame from "../../components/imageInBrowserFrame";
 
 export default function PostgresToHubspot() {
   return (
@@ -168,8 +169,7 @@ export default function PostgresToHubspot() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/postgres/add-postgres-app.png"
                 alt="Grouparoo Postgres settings"
                 width={742}
@@ -180,8 +180,7 @@ export default function PostgresToHubspot() {
           <br />
           <Row className="align-items-center">
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/postgres/postgres-table-mode.png"
                 alt="Grouparoo table source settings"
                 width={742}
@@ -213,8 +212,7 @@ export default function PostgresToHubspot() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/hubspot/grouparoo-to-hubspot.png"
                 alt="Map data to Hubspot"
                 width={742}

--- a/pages/integrations/postgres-to-salesforce.tsx
+++ b/pages/integrations/postgres-to-salesforce.tsx
@@ -3,6 +3,7 @@ import Image from "../../components/Image";
 import IntegrationCard from "../../components/home/integrationCard";
 import SEO from "../../components/seo";
 import BigArrow from "../../components/bigArrow";
+import ImageInBrowserFrame from "../../components/imageInBrowserFrame";
 
 export default function PostgresToSalesforce() {
   return (
@@ -176,8 +177,7 @@ export default function PostgresToSalesforce() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/postgres/add-postgres-app.png"
                 alt="Grouparoo Postgres settings"
                 width={742}
@@ -188,8 +188,7 @@ export default function PostgresToSalesforce() {
           <br />
           <Row className="align-items-center">
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/postgres/postgres-table-mode.png"
                 alt="Grouparoo table source settings"
                 width={742}
@@ -221,8 +220,7 @@ export default function PostgresToSalesforce() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="productScreenshots border"
+              <ImageInBrowserFrame
                 src="/images/home/integrations/salesforce/grouparoo-to-salesforce.png"
                 alt="Map data to Salesforce"
                 width={742}

--- a/pages/solutions/education.tsx
+++ b/pages/solutions/education.tsx
@@ -4,6 +4,7 @@ import Image from "../../components/Image";
 import SEO from "../../components/seo";
 import IntegrationsSection from "../../components/home/integrationsSection";
 import GetStarted from "../../components/home/getStarted";
+import ImageInBrowserFrame from "../../components/imageInBrowserFrame";
 
 export default function Education() {
   return (
@@ -164,8 +165,7 @@ export default function Education() {
               </div>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-1.png"
                 alt="Grouparoo profile"
                 width={650}
@@ -184,8 +184,7 @@ export default function Education() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-2.png"
                 alt="Grouparoo groups"
                 width={650}
@@ -205,8 +204,7 @@ export default function Education() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-3.png"
                 alt="Grouparoo destination"
                 width={650}
@@ -225,8 +223,7 @@ export default function Education() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-4.png"
                 alt="Data synced to destination"
                 width={650}

--- a/pages/solutions/healthcare.tsx
+++ b/pages/solutions/healthcare.tsx
@@ -4,6 +4,7 @@ import Image from "../../components/Image";
 import Head from "next/head";
 import IntegrationsSection from "../../components/home/integrationsSection";
 import GetStarted from "../../components/home/getStarted";
+import ImageInBrowserFrame from "../../components/imageInBrowserFrame";
 
 export default function Healthcare() {
   return (
@@ -162,8 +163,7 @@ export default function Healthcare() {
               </div>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-1.png"
                 alt="Grouparoo profile"
                 width={650}
@@ -182,8 +182,7 @@ export default function Healthcare() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-2.png"
                 alt="Grouparoo groups"
                 width={650}
@@ -202,8 +201,7 @@ export default function Healthcare() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-3.png"
                 alt="Grouparoo destination"
                 width={650}
@@ -222,8 +220,7 @@ export default function Healthcare() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-4.png"
                 alt="Data synced to destination"
                 width={650}

--- a/pages/solutions/marketers.tsx
+++ b/pages/solutions/marketers.tsx
@@ -5,6 +5,7 @@ import Head from "next/head";
 import IntegrationsSection from "../../components/home/integrationsSection";
 import GetStarted from "../../components/home/getStarted";
 import WhyOpenSource from "../../components/home/whyOpenSource";
+import ImageInBrowserFrame from "../../components/imageInBrowserFrame";
 
 export default function IndexPage() {
   return (
@@ -166,8 +167,7 @@ export default function IndexPage() {
               </div>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-1.png"
                 alt="Grouparoo profile"
                 width={650}
@@ -186,8 +186,7 @@ export default function IndexPage() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-2.png"
                 alt="Grouparoo groups"
                 width={650}
@@ -205,8 +204,7 @@ export default function IndexPage() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-3.png"
                 alt="Grouparoo destination"
                 width={650}
@@ -225,8 +223,7 @@ export default function IndexPage() {
               </p>
             </Col>
             <Col md={8}>
-              <Image
-                className="howItWorksImage"
+              <ImageInBrowserFrame
                 src="/images/home/how-it-works-4.png"
                 alt="Data synced to destination"
                 width={650}

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -121,16 +121,6 @@ a {
   color: $grouparoo-blue;
 }
 
-.howItWorksImage {
-  box-shadow: 7px 6px 13px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-}
-
-.imageOutline {
-  border-color: lightgray;
-  border-width: 2px;
-  border-style: solid;
-}
 // -- Comparison Pages --
 .comparisonContent {
   p,
@@ -175,10 +165,6 @@ a {
   width: 30%;
 }
 // -- Integrations Pages --
-.productScreenshots {
-  box-shadow: 7px 6px 13px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-}
 
 .integrationsBlueH3 {
   color: $grouparoo-blue;
@@ -189,6 +175,12 @@ a {
 }
 
 // -- Page Content --
+.imageOutline {
+  border-color: lightgray;
+  border-width: 2px;
+  border-style: solid;
+}
+
 code[class*="language-"] {
   font-size: 14px;
   line-height: 10px;


### PR DESCRIPTION
Replaces `productScreenshots` and `howItWorksImage` with a new ImageInBrowserFrame!

<img width="1390" alt="Screen Shot 2021-05-19 at 10 45 35 PM" src="https://user-images.githubusercontent.com/303226/118925855-43906680-b8f4-11eb-99ab-f0825324a28b.png">
<img width="1581" alt="Screen Shot 2021-05-19 at 10 46 22 PM" src="https://user-images.githubusercontent.com/303226/118925864-468b5700-b8f4-11eb-8964-e1085210ae36.png">

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="1639" alt="Screen Shot 2021-05-20 at 8 12 45 AM" src="https://user-images.githubusercontent.com/303226/119004514-7e6dbb00-b943-11eb-8d69-fed3d1b94222.png">
</td>
<td>
<img width="1639" alt="Screen Shot 2021-05-20 at 8 12 47 AM" src="https://user-images.githubusercontent.com/303226/119004553-8594c900-b943-11eb-8233-9ba4d112909a.png">
</td>
</tr>
</table>