### PR TITLE
adjusted mobile view

### DIFF
--- a/components/home/integrationCard.tsx
+++ b/components/home/integrationCard.tsx
@@ -30,7 +30,7 @@ export default function IntegrationCard({
         text="white"
         className={showLink ? "integrationCard" : ""}
       >
-        <Card.Body>
+        <Card.Body className="">
           <SmallIntegration
             fillWidth={true}
             image={image}
@@ -64,7 +64,7 @@ export default function IntegrationCard({
           )}
           {category ? (
             <>
-              <Badge pill variant="primary">
+              <Badge pill variant="primary" className="text-wrap m-1">
                 {" "}
                 {category.toUpperCase()}
               </Badge>

--- a/components/home/integrationCard.tsx
+++ b/components/home/integrationCard.tsx
@@ -24,13 +24,14 @@ export default function IntegrationCard({
   const card = (
     <div
       style={{ borderRadius: "5px", boxShadow: "5px 5px 5px 5px lightgrey" }}
+      className="h-100"
     >
       <Card
         bg="dark"
         text="white"
-        className={showLink ? "integrationCard" : ""}
+        className={showLink ? "integrationCard h-100" : "h-100"}
       >
-        <Card.Body className="">
+        <Card.Body>
           <SmallIntegration
             fillWidth={true}
             image={image}

--- a/pages/integrations.tsx
+++ b/pages/integrations.tsx
@@ -60,6 +60,7 @@ export default function IntegrationsPage() {
                       sm={6}
                       xs={6}
                       key={`plugin-${plugin.name}`}
+                      className="py-4"
                     >
                       <IntegrationCard
                         name={plugin.name}


### PR DESCRIPTION
Previously, labels overflowed cards on mobile and sizes did not match on all device sizes:
<img width="301" alt="Screen Shot 2021-05-20 at 5 28 09 PM" src="https://user-images.githubusercontent.com/63751206/119065217-e4812f00-b991-11eb-8c28-7d939846a8cf.png">

This update fixes that:
<img width="369" alt="Screen Shot 2021-05-20 at 5 52 13 PM" src="https://user-images.githubusercontent.com/63751206/119066202-1eebcb80-b994-11eb-9ac4-aed61bcf50b2.png">
