### PR TITLE
Collapse the lighthouse report comment

### DIFF
--- a/scripts/write_lighthouse_comment.ts
+++ b/scripts/write_lighthouse_comment.ts
@@ -92,8 +92,11 @@ function getComment(urlData, urlReport) {
 
   const output = `
 **Lighthouse Performance Results**
-<details><summary>Click to Expand</summary>
+<details>
+<summary>Click to Expand</summary>
+
 ${makeTable(table)}
+
 </details>
   `;
 

--- a/scripts/write_lighthouse_comment.ts
+++ b/scripts/write_lighthouse_comment.ts
@@ -90,7 +90,13 @@ function getComment(urlData, urlReport) {
     table.push([title, performance, accessibility, practices, seo]);
   }
 
-  const output = makeTable(table);
+  const output = `
+**Lighthouse Performance Results**
+<details><summary>Click to Expand</summary>
+${makeTable(table)}
+</details>
+  `;
+
   return output;
 }
 


### PR DESCRIPTION
Hides the Lighthouse report table in a "Click to Expand"

<img width="951" alt="Screen Shot 2021-05-27 at 1 20 24 PM" src="https://user-images.githubusercontent.com/303226/119891866-560b3100-beee-11eb-873a-59c859cd60db.png">
<img width="952" alt="Screen Shot 2021-05-27 at 1 20 27 PM" src="https://user-images.githubusercontent.com/303226/119891876-573c5e00-beee-11eb-9230-4a71a5d4ee06.png">
