### PR TITLE
adding examples for group rules to docs

### DIFF
--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -6,6 +6,8 @@ import {
   Tabs,
   Tab,
   Table,
+  Row,
+  Col,
   NavItem,
 } from "react-bootstrap";
 import pgRuleOps from "../../data/property-ops-dictionary--postgres.json";
@@ -79,7 +81,7 @@ const DataTable = ({ data, heading, eventKey }) => {
                 format: <br />
                 <span className="pl-4">
                   <b>YYYY-MM-DDThh:mm:ss.mmm+TZD</b>{" "}
-                  ("2020-09-01T08:15:00+00:00")
+                  ("2020-09-01T08:15:00+00:00"){" "}
                 </span>
                 A date passed as YYYY-MM-DD will pass validation, but may result
                 in less accurate group results.
@@ -88,40 +90,26 @@ const DataTable = ({ data, heading, eventKey }) => {
             The following operators are available on <code>{heading}</code>{" "}
             properties:
           </p>
-          <div className="table-responsive">
-            <Table>
-              <thead>
-                <tr>
-                  <th scope="col">Operator</th>
-                  <th scope="col">Description</th>
-                  <th scope="col" className="d-none d-md-table-cell">
-                    Example
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.map((item, idx) => (
-                  <tr key={idx}>
-                    <td className="col-6 col-md-3">
-                      <code>{item.op}</code>
-                    </td>
-                    <td className="col-6 col-md-3">{item.description}</td>
-                    <td className="col-12 col-md-6">
-                      {" "}
-                      {item.example ? (
-                        <>
-                          <div>
-                            <CodeBlock value={item.example} />
-                            <p className="pl-2">{item.caption}</p>
-                          </div>
-                        </>
-                      ) : null}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </div>
+
+          {data.map((item, idx) => (
+            <Row
+              key={idx}
+              className="border border-top-light border-bottom-light pt-3 pb-2  align-items-center pl-lg-5 pr-lg-3"
+            >
+              <Col className="text-center col-lg-4 mx-auto mx-0 pl-4 pl-lg-0">
+                <Row>
+                  <code className="h5">{item.op}</code>
+                </Row>
+                <Row>{item.description}</Row>
+              </Col>
+              <Col className="col-12 col-lg-8 mx-auto">
+                <div className="overflow-hidden">
+                  <CodeBlock value={item.example} />
+                </div>
+                <small className="pl-2">{item.caption}</small>
+              </Col>
+            </Row>
+          ))}
         </Fragment>
       </Accordion.Collapse>
     </Fragment>

--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -28,6 +28,16 @@ const propertyTypes = [
 interface PropertyOperations {
   description: string;
   op: string;
+  example: {
+    propertyId: string;
+    operation: {
+      op: string;
+    };
+    match?: string;
+    relativeMatch?: string;
+    relativeMatchUnit?: string;
+  };
+  caption: string;
 }
 
 interface RuleOpsDbTypeData {
@@ -104,7 +114,10 @@ const DataTable = ({ data, heading, eventKey }) => {
               </Col>
               <Col className="col-12 col-lg-8 mx-auto">
                 <div className="overflow-hidden">
-                  <CodeBlock value={item.example} />
+                  <CodeBlock
+                    value={JSON.stringify(item.example, null, 2)}
+                    language="json"
+                  />
                 </div>
                 <div className="pl-2">
                   <small>{item.caption}</small>

--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -106,7 +106,9 @@ const DataTable = ({ data, heading, eventKey }) => {
                 <div className="overflow-hidden">
                   <CodeBlock value={item.example} />
                 </div>
-                <small className="pl-2">{item.caption}</small>
+                <div className="pl-2">
+                  <small>{item.caption}</small>
+                </div>
               </Col>
             </Row>
           ))}

--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -79,7 +79,7 @@ const DataTable = ({ data, heading, eventKey }) => {
                 format: <br />
                 <span className="pl-4">
                   <b>YYYY-MM-DDThh:mm:ss.mmm+TZD</b>{" "}
-                  ("2020-09-01T08:15:00-8:00")
+                  ("2020-09-01T08:15:00+00:00")
                 </span>
                 A date passed as YYYY-MM-DD will pass validation, but may result
                 in less accurate group results.
@@ -88,36 +88,40 @@ const DataTable = ({ data, heading, eventKey }) => {
             The following operators are available on <code>{heading}</code>{" "}
             properties:
           </p>
-          <Table>
-            <thead>
-              <tr>
-                <th scope="col">Operator</th>
-                <th scope="col">Description</th>
-                {heading === "date" ? <th scope="col">Example</th> : null}
-              </tr>
-            </thead>
-            <tbody>
-              {data.map((item, idx) => (
-                <tr key={idx}>
-                  <td>
-                    <code>{item.op}</code>
-                  </td>
-                  <td>{item.description}</td>
-                  <td>
-                    {" "}
-                    {item.example ? (
-                      <>
-                        <div className="col-10">
-                          <CodeBlock value={item.example} />
-                          <p className="pl-2">{item.caption}</p>
-                        </div>
-                      </>
-                    ) : null}
-                  </td>
+          <div className="table-responsive">
+            <Table>
+              <thead>
+                <tr>
+                  <th scope="col">Operator</th>
+                  <th scope="col">Description</th>
+                  <th scope="col" className="d-none d-md-table-cell">
+                    Example
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </Table>
+              </thead>
+              <tbody>
+                {data.map((item, idx) => (
+                  <tr key={idx}>
+                    <td className="col-6 col-md-3">
+                      <code>{item.op}</code>
+                    </td>
+                    <td className="col-6 col-md-3">{item.description}</td>
+                    <td className="col-12 col-md-6">
+                      {" "}
+                      {item.example ? (
+                        <>
+                          <div>
+                            <CodeBlock value={item.example} />
+                            <p className="pl-2">{item.caption}</p>
+                          </div>
+                        </>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
         </Fragment>
       </Accordion.Collapse>
     </Fragment>

--- a/components/docs/ruleOpsTable.tsx
+++ b/components/docs/ruleOpsTable.tsx
@@ -1,7 +1,16 @@
 import { Fragment } from "react";
-import { Accordion, Button, Tabs, Tab, Table } from "react-bootstrap";
+import {
+  Alert,
+  Accordion,
+  Button,
+  Tabs,
+  Tab,
+  Table,
+  NavItem,
+} from "react-bootstrap";
 import pgRuleOps from "../../data/property-ops-dictionary--postgres.json";
 import sqliteRuleOps from "../../data/property-ops-dictionary--sqlite.json";
+import CodeBlock from "../code";
 
 const propertyTypes = [
   "boolean",
@@ -64,14 +73,27 @@ const DataTable = ({ data, heading, eventKey }) => {
       <Accordion.Collapse eventKey={eventKey}>
         <Fragment>
           <p>
+            {heading === "date" ? (
+              <Alert variant="primary">
+                💡 Dates used for calculated groups should use full ISO-8601
+                format: <br />
+                <span className="pl-4">
+                  <b>YYYY-MM-DDThh:mm:ss.mmm+TZD</b>{" "}
+                  ("2020-09-01T08:15:00-8:00")
+                </span>
+                A date passed as YYYY-MM-DD will pass validation, but may result
+                in less accurate group results.
+              </Alert>
+            ) : null}
             The following operators are available on <code>{heading}</code>{" "}
             properties:
           </p>
           <Table>
             <thead>
               <tr>
-                <th>Operator</th>
-                <th>Description</th>
+                <th scope="col">Operator</th>
+                <th scope="col">Description</th>
+                {heading === "date" ? <th scope="col">Example</th> : null}
               </tr>
             </thead>
             <tbody>
@@ -81,6 +103,17 @@ const DataTable = ({ data, heading, eventKey }) => {
                     <code>{item.op}</code>
                   </td>
                   <td>{item.description}</td>
+                  <td>
+                    {" "}
+                    {item.example ? (
+                      <>
+                        <div className="col-10">
+                          <CodeBlock value={item.example} />
+                          <p className="pl-2">{item.caption}</p>
+                        </div>
+                      </>
+                    ) : null}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/data/property-ops-dictionary--postgres.json
+++ b/data/property-ops-dictionary--postgres.json
@@ -21,7 +21,7 @@
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"subscribed\": \"?????\", \n  \"operation\": {\"ne\": \"true\" }\n}",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"ne\": \"true\" }\n}",
       "caption": "All non-subscribers"
     }
   ],

--- a/data/property-ops-dictionary--postgres.json
+++ b/data/property-ops-dictionary--postgres.json
@@ -3,25 +3,39 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "exists" }
+      },
       "caption": "All profiles that do not have data about subscription status"
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles that have data about subscription status"
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"eq\": \"true\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "eq" },
+        "match": "true"
+      },
       "caption": "All subscribers"
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"ne\": \"true\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "ne" },
+        "match": "true"
+      },
       "caption": "All non-subscribers"
     }
   ],
@@ -29,61 +43,109 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "exists" }
+      },
       "caption": "All profiles who have made a purchase"
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles who have not made a purchase"
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "eq" },
+        "match": "2021-05-25T04:45:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase was on May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "ne" },
+        "match": "2021-05-25T04:45:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase was anytime except May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "gt",
       "description": "is after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00.00+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "lt" },
+        "match": "2020-12-25T04:45:00.00+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is after December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "lt",
       "description": "is before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "lt" },
+        "match": "2021-05-25T09:30:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is prior to May 25, 2021 9:30:00 AM UTC."
     },
     {
       "op": "gte",
       "description": "is on or after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"2019-06-14T18:16:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "gte" },
+        "match": "2019-06-14T18:16:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is exactly at or after June 14, 2019 at 6:16 PM UTC"
     },
     {
       "op": "lte",
       "description": "is on or before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "lte" },
+        "match": "2020-12-25T04:45:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "relative_gt",
       "description": "is in the past",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"relative_gt\" },\n  \"relativeMatchNumber\": \"60\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "relative_gt" },
+        "relativeMatchNumber": "60",
+        "relativeMatchUnit": "days",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is within the last 60 days"
     },
     {
       "op": "relative_lt",
       "description": "is in the future",
-      "example": "{\n  \"propertyId\": \"subscription_ends\", \n  \"operation\": {\"op\": \"relative_lt\" },\n  \"relativeMatchNumber\": \"30\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "subscription_ends",
+        "operation": { "op": "relative_lt" },
+        "relativeMatchNumber": "30",
+        "relativeMatchUnit": "days",
+        "type": "date"
+      },
       "caption": "All profiles whose subscription ends within the next 30 days"
     }
   ],
@@ -91,67 +153,103 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"exists\" },\n \n}",
+      "example": { "propertyId": "email", "operation": { "op": "exists" } },
       "caption": "All profiles with an email address listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notExists\" },\n \n}",
+      "example": { "propertyId": "email", "operation": { "op": "notExists" } },
       "caption": "All profiles without an email address listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "eq" },
+        "match": "hello@grouparoo.com"
+      },
       "caption": "All profiles with an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "ne" },
+        "match": "hello@grouparoo.com"
+      },
       "caption": "All profiles without an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%smith%\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "like" },
+        "match": "%smith%"
+      },
       "caption": "All profiles with an email address containing smith (case sensitive)."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%smith%\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "notLike" },
+        "match": "%smith%"
+      },
       "caption": "All profiles without an email address containing smith (case sensitive)."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"test\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "startsWith" },
+        "match": "test"
+      },
       "caption": "All profiles with an email address starting with \"test\" (case sensitive)."
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"grouparoo.com\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "endsWith" },
+        "match": "grouparoo.com"
+      },
       "caption": "All profiles with an email address ending with \"@grouparoo.com\" (case sensitive)."
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "substring" },
+        "match": "grouparoo"
+      },
       "caption": "All profiles with an email address containing \"grouparoo\"."
     },
     {
       "op": "iLike",
       "description": "is like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%smith%\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "like" },
+        "match": "%smith%"
+      },
       "caption": "All profiles with an email address containing smith (case insensitive)."
     },
     {
       "op": "notILike",
       "description": "is not like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notILike\" },\n  \"match\": \"%smith%\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "notILike" },
+        "match": "%smith%"
+      },
       "caption": "All profiles without an email address containing smith (case insensitive))."
     }
   ],
@@ -159,49 +257,73 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": { "propertyId": "ltv", "operation": { "op": "exists" } },
       "caption": "All profiles with an LTV value."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": { "propertyId": "ltv", "operation": { "op": "notExists" } },
       "caption": "All profiles without an LTV value."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "eq" },
+        "match": "113932.97"
+      },
       "caption": "All profiles with an LTV of exactly $113,932.97."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "ne" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of exactly $113,932.97."
     },
     {
       "op": "gt",
       "description": "is greater than",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gt\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "gt" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of greater than $113,932.97."
     },
     {
       "op": "lt",
       "description": "is less than",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "lt" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of less than $113,932.97."
     },
     {
       "op": "gte",
       "description": "is greater than or equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "gte" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of exactly $113,932.97. or more"
     },
     {
       "op": "lte",
       "description": "is less than or equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "lte" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of exactly $113,932.97. or less"
     }
   ],
@@ -209,49 +331,73 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": { "propertyId": "visits", "operation": { "op": "notExists" } },
       "caption": "All profiles with any value in the \"visits\" field."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": { "propertyId": "visits", "operation": { "op": "notExists" } },
       "caption": "All profiles with an empty \"visits\" field."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "eq" },
+        "match": "6"
+      },
       "caption": "All profiles with exactly six visits."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "ne" },
+        "match": "6"
+      },
       "caption": "All profiles with any number of visits except six."
     },
     {
       "op": "gt",
       "description": "is greater than",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gt\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "gt" },
+        "match": "6"
+      },
       "caption": "All profiles with more than six visits."
     },
     {
       "op": "lt",
       "description": "is less than",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "ne" },
+        "match": "6"
+      },
       "caption": "All profiles with less than six visits."
     },
     {
       "op": "gte",
       "description": "is greater than or equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gte\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "gte" },
+        "match": "6"
+      },
       "caption": "All profiles with six or more visits."
     },
     {
       "op": "lte",
       "description": "is less than or equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"lte\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "lte" },
+        "match": "6"
+      },
       "caption": "All profiles with 6 or fewer visits."
     }
   ],
@@ -259,67 +405,103 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": { "propertyId": "phone", "operation": { "op": "exists" } },
       "caption": "All profiles with a phone number listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "example": { "propertyId": "phone", "operation": { "op": "notExists" } },
       "caption": "All profiles without a phone number listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"+1-555-555-5555\" }",
-      "caption": "All profiles with a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "eq" },
+        "match": "+1-555-555-5555"
+      },
+      "caption": "All profiles with a phone number of +1-555-555-5555."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"+1-555-555-5555\" }",
-      "caption": "All profiles without a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "ne" },
+        "match": "+1-555-555-5555"
+      },
+      "caption": "All profiles without a phone number of +1-555-555-5555."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%780%\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "like" },
+        "match": "%780%"
+      },
       "caption": "All profiles with a phone number containing 780."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "notLike" },
+        "match": "%780%"
+      },
       "caption": "All profiles without a phone number containing 780."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"+1\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "startsWith" },
+        "match": "+1"
+      },
       "caption": "All profiles with a phone number starting with +1."
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "startsWith" },
+        "match": "80"
+      },
       "caption": "All profiles with a phone number ending with 80."
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "startsWith" },
+        "match": "80"
+      },
       "caption": "All profiles with a phone number containing the substring 80."
     },
     {
       "op": "iLike",
       "description": "is like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "notLike" },
+        "match": "%780%"
+      },
       "caption": "All profiles without a phone number containing 780."
     },
     {
       "op": "notILike",
       "description": "is not like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "notLike" },
+        "match": "%780%"
+      },
       "caption": "All profiles without a phone number containing 780."
     }
   ],
@@ -327,67 +509,106 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": { "propertyId": "lastName", "operation": { "op": "exists" } },
       "caption": "All profiles with a last name listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles without a last name listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"Ramirez\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "eq" },
+        "match": "Ramirez"
+      },
       "caption": "All profiles with a last name of exactly Ramirez."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"Ramirez\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "ne" },
+        "match": "Ramirez"
+      },
       "caption": "All profiles without a last name of exactly Ramirez."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"__m%\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "like" },
+        "match": "__m%"
+      },
       "caption": "All profiles with a last name that has a third letter of m."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"__m%\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "notLike" },
+        "match": "__m%"
+      },
       "caption": "All profiles without a last name that has a third letter of m."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"Mc\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "startsWith" },
+        "match": "Mc"
+      },
       "caption": "All profiles with a last name starting with Mc (case sensitive)"
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"son\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "endsWith" },
+        "match": "son"
+      },
       "caption": "All profiles with a last name ending with son (case sensitive)."
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"al\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "substring" },
+        "match": "al"
+      },
       "caption": "All profiles with a last name containing al (case sensitive)."
     },
     {
       "op": "iLike",
       "description": "is like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"iLike\" },\n  \"match\": \"%al%\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "iLike" },
+        "match": "%al%"
+      },
       "caption": "All profiles with a last name containing al (case insensitive)."
     },
     {
       "op": "notILike",
       "description": "is not like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"iLike\" },\n  \"match\": \"%al%\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "iLike" },
+        "match": "%al%"
+      },
       "caption": "All profiles without a last name containing al (case insensitive)."
     }
   ],
@@ -395,67 +616,109 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "exists" }
+      },
       "caption": "All profiles with a company URL listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles without a company URL listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "eq" },
+        "match": "https://www.grouparoo.com"
+      },
       "caption": "All profiles with a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "ne" },
+        "match": "https://www.grouparoo.com"
+      },
       "caption": "All profiles without a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "like" },
+        "match": "%grouparoo.com"
+      },
       "caption": "All profiles with a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "like" },
+        "match": "%grouparoo.com"
+      },
       "caption": "All profiles without a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"https\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "startsWith" },
+        "match": "https"
+      },
       "caption": "All profiles with a company URL starting with https (case sensitive)."
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \".com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "startsWith" },
+        "match": ".com"
+      },
       "caption": "All profiles with a company URL ending with .com (case sensitive)"
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "substring" },
+        "match": "grouparoo"
+      },
       "caption": "All profiles with a company URL containing grouparoo (case sensitive)"
     },
     {
       "op": "iLike",
       "description": "is like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"%Grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "substring" },
+        "match": "%Grouparoo.com"
+      },
       "caption": "All profiles with a company URL containing anything followed by Grouparoo.com (case insensitive)."
     },
     {
       "op": "notILike",
       "description": "is not like (case insensitive)",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"%Grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "substring" },
+        "match": "%Grouparoo.com"
+      },
       "caption": "All profiles without a company URL containing anything followed by Grouparoo.com (case insensitive)."
     }
   ],

--- a/data/property-ops-dictionary--postgres.json
+++ b/data/property-ops-dictionary--postgres.json
@@ -2,19 +2,27 @@
   "boolean": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "caption": "All profiles that do not have data about subscription status"
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles that have data about subscription status"
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"eq\": \"true\" }\n}",
+      "caption": "All subscribers"
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"subscribed\": \"?????\", \n  \"operation\": {\"ne\": \"true\" }\n}",
+      "caption": "All non-subscribers"
     }
   ],
   "date": [
@@ -22,313 +30,433 @@
       "op": "exists",
       "description": "exists with any value",
       "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"exists\" }\n}",
-      "caption": "All users who have made a purchase"
+      "caption": "All profiles who have made a purchase"
     },
     {
       "op": "notExists",
       "description": "does not exist",
       "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
-      "caption": "All users who have not made a purchase"
+      "caption": "All profiles who have not made a purchase"
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"2021-05-25T04:45:00.000-7:00\"\n}",
-      "caption": "All users whose most recent purchase was on May 25, 2021 at exactly 4:45AM PDT."
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase was on May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"2021-05-25T04:45:00.000-7:00\"\n}",
-      "caption": "All users whose most recent purchase was anytime except May 25, 2021 at exactly 4:45AM PDT."
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase was anytime except May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "gt",
       "description": "is after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00.000-7:00\"\n}",
-      "caption": "All users whose most recent purchase is after December 25, 2020 at 04:45:00 PDT."
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00.00+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is after December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "lt",
       "description": "is before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00.000-7:00\"\n}",
-      "caption": "All users whose most recent purchase is prior to May 25, 2021 9:30:00 AM PDT."
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is prior to May 25, 2021 9:30:00 AM UTC."
     },
     {
       "op": "gte",
       "description": "is on or after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"2019-06-14T18:16:00.000-07:00\"\n}",
-      "caption": "All users whose most recent purchase is exactly at or after June 14, 2019 at 6:16 PM PDT"
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"2019-06-14T18:16:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is exactly at or after June 14, 2019 at 6:16 PM UTC"
     },
     {
       "op": "lte",
       "description": "is on or before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00.000-7:00\"\n}",
-      "caption": "All users whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 PDT."
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "relative_gt",
       "description": "is in the past",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"relative_gt\" },\n  \"relativeMatchNumber\": \"60\",\n  \"relativeMatchUnit\": \"days\"\n}",
-      "caption": "All users whose most recent purchase is within the last 60 days"
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"relative_gt\" },\n  \"relativeMatchNumber\": \"60\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is within the last 60 days"
     },
     {
       "op": "relative_lt",
       "description": "is in the future",
-      "example": "{\n  \"propertyId\": \"subscription_ends\", \n  \"operation\": {\"op\": \"relative_lt\" },\n  \"relativeMatchNumber\": \"30\",\n  \"relativeMatchUnit\": \"days\"\n}",
-      "caption": "All users whose subscription ends within the next 30 days"
+      "example": "{\n  \"propertyId\": \"subscription_ends\", \n  \"operation\": {\"op\": \"relative_lt\" },\n  \"relativeMatchNumber\": \"30\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose subscription ends within the next 30 days"
     }
   ],
   "email": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"exists\" },\n \n}",
+      "caption": "All profiles with an email address listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notExists\" },\n \n}",
+      "caption": "All profiles without an email address listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "caption": "All profiles with an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "caption": "All profiles without an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%smith%\",\n}",
+      "caption": "All profiles with an email address containing smith (case sensitive)."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%smith%\",\n}",
+      "caption": "All profiles without an email address containing smith (case sensitive)."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"test\",\n}",
+      "caption": "All profiles with an email address starting with \"test\" (case sensitive)."
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"grouparoo.com\",\n}",
+      "caption": "All profiles with an email address ending with \"@grouparoo.com\" (case sensitive)."
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\",\n}",
+      "caption": "All profiles with an email address containing \"grouparoo\"."
     },
     {
       "op": "iLike",
-      "description": "is like (case insensitive)"
+      "description": "is like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%smith%\",\n}",
+      "caption": "All profiles with an email address containing smith (case insensitive)."
     },
     {
       "op": "notILike",
-      "description": "is not like (case insensitive)"
+      "description": "is not like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notILike\" },\n  \"match\": \"%smith%\",\n}",
+      "caption": "All profiles without an email address containing smith (case insensitive))."
     }
   ],
   "float": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with an LTV value."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles without an LTV value."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles with an LTV of exactly $113,932.97."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of exactly $113,932.97."
     },
     {
       "op": "gt",
-      "description": "is greater than"
+      "description": "is greater than",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gt\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of greater than $113,932.97."
     },
     {
       "op": "lt",
-      "description": "is less than"
+      "description": "is less than",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of less than $113,932.97."
     },
     {
       "op": "gte",
-      "description": "is greater than or equal to"
+      "description": "is greater than or equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of exactly $113,932.97. or more"
     },
     {
       "op": "lte",
-      "description": "is less than or equal to"
+      "description": "is less than or equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of exactly $113,932.97. or less"
     }
   ],
   "integer": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles with any value in the \"visits\" field."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles with an empty \"visits\" field."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with exactly six visits."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with any number of visits except six."
     },
     {
       "op": "gt",
-      "description": "is greater than"
+      "description": "is greater than",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gt\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with more than six visits."
     },
     {
       "op": "lt",
-      "description": "is less than"
+      "description": "is less than",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with less than six visits."
     },
     {
       "op": "gte",
-      "description": "is greater than or equal to"
+      "description": "is greater than or equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gte\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with six or more visits."
     },
     {
       "op": "lte",
-      "description": "is less than or equal to"
+      "description": "is less than or equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"lte\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with 6 or fewer visits."
     }
   ],
   "phoneNumber": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with a phone number listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "caption": "All profiles without a phone number listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"+1-555-555-5555\" }",
+      "caption": "All profiles with a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"+1-555-555-5555\" }",
+      "caption": "All profiles without a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%780%\" }",
+      "caption": "All profiles with a phone number containing 780."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "caption": "All profiles without a phone number containing 780."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"+1\" }",
+      "caption": "All profiles with a phone number starting with +1."
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "caption": "All profiles with a phone number ending with 80."
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "caption": "All profiles with a phone number containing the substring 80."
     },
     {
       "op": "iLike",
-      "description": "is like (case insensitive)"
+      "description": "is like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "caption": "All profiles without a phone number containing 780."
     },
     {
       "op": "notILike",
-      "description": "is not like (case insensitive)"
+      "description": "is not like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "caption": "All profiles without a phone number containing 780."
     }
   ],
   "string": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with a last name listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "caption": "All profiles without a last name listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"Ramirez\" }",
+      "caption": "All profiles with a last name of exactly Ramirez."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"Ramirez\" }",
+      "caption": "All profiles without a last name of exactly Ramirez."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"__m%\" }",
+      "caption": "All profiles with a last name that has a third letter of m."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"__m%\" }",
+      "caption": "All profiles without a last name that has a third letter of m."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"Mc\" }",
+      "caption": "All profiles with a last name starting with Mc (case sensitive)"
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"son\" }",
+      "caption": "All profiles with a last name ending with son (case sensitive)."
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"al\" }",
+      "caption": "All profiles with a last name containing al (case sensitive)."
     },
     {
       "op": "iLike",
-      "description": "is like (case insensitive)"
+      "description": "is like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"iLike\" },\n  \"match\": \"%al%\" }",
+      "caption": "All profiles with a last name containing al (case insensitive)."
     },
     {
       "op": "notILike",
-      "description": "is not like (case insensitive)"
+      "description": "is not like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"iLike\" },\n  \"match\": \"%al%\" }",
+      "caption": "All profiles without a last name containing al (case insensitive)."
     }
   ],
   "url": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with a company URL listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "caption": "All profiles without a company URL listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "caption": "All profiles with a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "caption": "All profiles without a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "caption": "All profiles with a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "caption": "All profiles without a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"https\" }",
+      "caption": "All profiles with a company URL starting with https (case sensitive)."
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \".com\" }",
+      "caption": "All profiles with a company URL ending with .com (case sensitive)"
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\" }",
+      "caption": "All profiles with a company URL containing grouparoo (case sensitive)"
     },
     {
       "op": "iLike",
-      "description": "is like (case insensitive)"
+      "description": "is like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"%Grouparoo.com\" }",
+      "caption": "All profiles with a company URL containing anything followed by Grouparoo.com (case insensitive)."
     },
     {
       "op": "notILike",
-      "description": "is not like (case insensitive)"
+      "description": "is not like (case insensitive)",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"%Grouparoo.com\" }",
+      "caption": "All profiles without a company URL containing anything followed by Grouparoo.com (case insensitive)."
     }
   ],
   "_relativeMatchUnits": ["days", "weeks", "months", "quarters", "years"],

--- a/data/property-ops-dictionary--postgres.json
+++ b/data/property-ops-dictionary--postgres.json
@@ -32,22 +32,26 @@
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"2021-05-25T04:45:00.000-7:00\"\n}",
+      "caption": "All users whose most recent purchase was on May 25, 2021 at exactly 4:45AM PDT."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"2021-05-25T04:45:00.000-7:00\"\n}",
+      "caption": "All users whose most recent purchase was anytime except May 25, 2021 at exactly 4:45AM PDT."
     },
     {
       "op": "gt",
       "description": "is after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00-7:00\"\n}",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00.000-7:00\"\n}",
       "caption": "All users whose most recent purchase is after December 25, 2020 at 04:45:00 PDT."
     },
     {
       "op": "lt",
       "description": "is before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00-7:00\"\n}",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00.000-7:00\"\n}",
       "caption": "All users whose most recent purchase is prior to May 25, 2021 9:30:00 AM PDT."
     },
     {
@@ -59,7 +63,7 @@
     {
       "op": "lte",
       "description": "is on or before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00-7:00\"\n}",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00.000-7:00\"\n}",
       "caption": "All users whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 PDT."
     },
     {

--- a/data/property-ops-dictionary--postgres.json
+++ b/data/property-ops-dictionary--postgres.json
@@ -20,11 +20,15 @@
   "date": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "caption": "All users who have made a purchase"
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All users who have not made a purchase"
     },
     {
       "op": "eq",
@@ -36,27 +40,39 @@
     },
     {
       "op": "gt",
-      "description": "is after"
+      "description": "is after",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00-7:00\"\n}",
+      "caption": "All users whose most recent purchase is after December 25, 2020 at 04:45:00 PDT."
     },
     {
       "op": "lt",
-      "description": "is before"
+      "description": "is before",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00-7:00\"\n}",
+      "caption": "All users whose most recent purchase is prior to May 25, 2021 9:30:00 AM PDT."
     },
     {
       "op": "gte",
-      "description": "is on or after"
+      "description": "is on or after",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"2019-06-14T18:16:00.000-07:00\"\n}",
+      "caption": "All users whose most recent purchase is exactly at or after June 14, 2019 at 6:16 PM PDT"
     },
     {
       "op": "lte",
-      "description": "is on or before"
+      "description": "is on or before",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00-7:00\"\n}",
+      "caption": "All users whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 PDT."
     },
     {
       "op": "relative_gt",
-      "description": "is in the past"
+      "description": "is in the past",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"relative_gt\" },\n  \"relativeMatchNumber\": \"60\",\n  \"relativeMatchUnit\": \"days\"\n}",
+      "caption": "All users whose most recent purchase is within the last 60 days"
     },
     {
       "op": "relative_lt",
-      "description": "is in the future"
+      "description": "is in the future",
+      "example": "{\n  \"propertyId\": \"subscription_ends\", \n  \"operation\": {\"op\": \"relative_lt\" },\n  \"relativeMatchNumber\": \"30\",\n  \"relativeMatchUnit\": \"days\"\n}",
+      "caption": "All users whose subscription ends within the next 30 days"
     }
   ],
   "email": [
@@ -311,13 +327,7 @@
       "description": "is not like (case insensitive)"
     }
   ],
-  "_relativeMatchUnits": [
-    "days",
-    "weeks",
-    "months",
-    "quarters",
-    "years"
-  ],
+  "_relativeMatchUnits": ["days", "weeks", "months", "quarters", "years"],
   "_convenientRules": {
     "exists": {
       "operation": {

--- a/data/property-ops-dictionary--sqlite.json
+++ b/data/property-ops-dictionary--sqlite.json
@@ -21,7 +21,7 @@
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"subscribed\": \"?????\", \n  \"operation\": {\"ne\": \"true\" }\n}",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"ne\": \"true\" }\n}",
       "caption": "All non-subscribers"
     }
   ],

--- a/data/property-ops-dictionary--sqlite.json
+++ b/data/property-ops-dictionary--sqlite.json
@@ -2,290 +2,416 @@
   "boolean": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "caption": "All profiles that do not have data about subscription status"
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles that have data about subscription status"
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"eq\": \"true\" }\n}",
+      "caption": "All subscribers"
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"subscribed\": \"?????\", \n  \"operation\": {\"ne\": \"true\" }\n}",
+      "caption": "All non-subscribers"
     }
   ],
   "date": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "caption": "All profiles who have made a purchase"
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles who have not made a purchase"
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase was on May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase was anytime except May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "gt",
-      "description": "is after"
+      "description": "is after",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00.00+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is after December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "lt",
-      "description": "is before"
+      "description": "is before",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is prior to May 25, 2021 9:30:00 AM UTC."
     },
     {
       "op": "gte",
-      "description": "is on or after"
+      "description": "is on or after",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"2019-06-14T18:16:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is exactly at or after June 14, 2019 at 6:16 PM UTC"
     },
     {
       "op": "lte",
-      "description": "is on or before"
+      "description": "is on or before",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "relative_gt",
-      "description": "is in the past"
+      "description": "is in the past",
+      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"relative_gt\" },\n  \"relativeMatchNumber\": \"60\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose most recent purchase is within the last 60 days"
     },
     {
       "op": "relative_lt",
-      "description": "is in the future"
+      "description": "is in the future",
+      "example": "{\n  \"propertyId\": \"subscription_ends\", \n  \"operation\": {\"op\": \"relative_lt\" },\n  \"relativeMatchNumber\": \"30\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "caption": "All profiles whose subscription ends within the next 30 days"
     }
   ],
   "email": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"exists\" },\n \n}",
+      "caption": "All profiles with an email address listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notExists\" },\n \n}",
+      "caption": "All profiles without an email address listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "caption": "All profiles with an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "caption": "All profiles without an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%smith%\",\n}",
+      "caption": "All profiles with an email address containing smith (case sensitive)."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%smith%\",\n}",
+      "caption": "All profiles without an email address containing smith (case sensitive)."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"test\",\n}",
+      "caption": "All profiles with an email address starting with \"test\" (case sensitive)."
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"grouparoo.com\",\n}",
+      "caption": "All profiles with an email address ending with \"@grouparoo.com\" (case sensitive)."
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\",\n}",
+      "caption": "All profiles with an email address containing \"grouparoo\"."
     }
   ],
   "float": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with an LTV value."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles without an LTV value."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles with an LTV of exactly $113,932.97."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of exactly $113,932.97."
     },
     {
       "op": "gt",
-      "description": "is greater than"
+      "description": "is greater than",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gt\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of greater than $113,932.97."
     },
     {
       "op": "lt",
-      "description": "is less than"
+      "description": "is less than",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of less than $113,932.97."
     },
     {
       "op": "gte",
-      "description": "is greater than or equal to"
+      "description": "is greater than or equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of exactly $113,932.97. or more"
     },
     {
       "op": "lte",
-      "description": "is less than or equal to"
+      "description": "is less than or equal to",
+      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"113932.97\"\n}",
+      "caption": "All profiles without an LTV of exactly $113,932.97. or less"
     }
   ],
   "integer": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles with any value in the \"visits\" field."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "caption": "All profiles with an empty \"visits\" field."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with exactly six visits."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with any number of visits except six."
     },
     {
       "op": "gt",
-      "description": "is greater than"
+      "description": "is greater than",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gt\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with more than six visits."
     },
     {
       "op": "lt",
-      "description": "is less than"
+      "description": "is less than",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with less than six visits."
     },
     {
       "op": "gte",
-      "description": "is greater than or equal to"
+      "description": "is greater than or equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gte\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with six or more visits."
     },
     {
       "op": "lte",
-      "description": "is less than or equal to"
+      "description": "is less than or equal to",
+      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"lte\" },\n  \"match\": \"6\"\n}",
+      "caption": "All profiles with 6 or fewer visits."
     }
   ],
   "phoneNumber": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with a phone number listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "caption": "All profiles without a phone number listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"+1-555-555-5555\" }",
+      "caption": "All profiles with a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"+1-555-555-5555\" }",
+      "caption": "All profiles without a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%780%\" }",
+      "caption": "All profiles with a phone number containing 780."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "caption": "All profiles without a phone number containing 780."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"+1\" }",
+      "caption": "All profiles with a phone number starting with +1."
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "caption": "All profiles with a phone number ending with 80."
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "caption": "All profiles with a phone number containing the substring 80."
     }
   ],
   "string": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with a last name listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "caption": "All profiles without a last name listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"Ramirez\" }",
+      "caption": "All profiles with a last name of exactly Ramirez."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"Ramirez\" }",
+      "caption": "All profiles without a last name of exactly Ramirez."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"__m%\" }",
+      "caption": "All profiles with a last name that has a third letter of m."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"__m%\" }",
+      "caption": "All profiles without a last name that has a third letter of m."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"Mc\" }",
+      "caption": "All profiles with a last name starting with Mc (case sensitive)"
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"son\" }",
+      "caption": "All profiles with a last name ending with son (case sensitive)."
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"al\" }",
+      "caption": "All profiles with a last name containing al (case sensitive)."
     }
   ],
   "url": [
     {
       "op": "exists",
-      "description": "exists with any value"
+      "description": "exists with any value",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "caption": "All profiles with a company URL listed."
     },
     {
       "op": "notExists",
-      "description": "does not exist"
+      "description": "does not exist",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "caption": "All profiles without a company URL listed."
     },
     {
       "op": "eq",
-      "description": "is equal to"
+      "description": "is equal to",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "caption": "All profiles with a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "ne",
-      "description": "is not equal to"
+      "description": "is not equal to",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "caption": "All profiles without a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "like",
-      "description": "is like (case sensitive)"
+      "description": "is like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "caption": "All profiles with a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "notLike",
-      "description": "is not like (case sensitive)"
+      "description": "is not like (case sensitive)",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "caption": "All profiles without a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "startsWith",
-      "description": "starts with"
+      "description": "starts with",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"https\" }",
+      "caption": "All profiles with a company URL starting with https (case sensitive)."
     },
     {
       "op": "endsWith",
-      "description": "ends with"
+      "description": "ends with",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \".com\" }",
+      "caption": "All profiles with a company URL ending with .com (case sensitive)"
     },
     {
       "op": "substring",
-      "description": "includes the string"
+      "description": "includes the string",
+      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\" }",
+      "caption": "All profiles with a company URL containing grouparoo (case sensitive)"
     }
   ],
-  "_relativeMatchUnits": [
-    "days",
-    "weeks",
-    "months",
-    "quarters",
-    "years"
-  ],
+  "_relativeMatchUnits": ["days", "weeks", "months", "quarters", "years"],
   "_convenientRules": {
     "exists": {
       "operation": {

--- a/data/property-ops-dictionary--sqlite.json
+++ b/data/property-ops-dictionary--sqlite.json
@@ -3,25 +3,39 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "exists" }
+      },
       "caption": "All profiles that do not have data about subscription status"
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles that have data about subscription status"
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"eq\": \"true\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "eq" },
+        "match": "true"
+      },
       "caption": "All subscribers"
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"subscribed\", \n  \"operation\": {\"ne\": \"true\" }\n}",
+      "example": {
+        "propertyId": "subscribed",
+        "operation": { "op": "ne" },
+        "match": "true"
+      },
       "caption": "All non-subscribers"
     }
   ],
@@ -29,61 +43,109 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"exists\" }\n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "exists" }
+      },
       "caption": "All profiles who have made a purchase"
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles who have not made a purchase"
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "eq" },
+        "match": "2021-05-25T04:45:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase was on May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"2021-05-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "ne" },
+        "match": "2021-05-25T04:45:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase was anytime except May 25, 2021 at exactly 4:45AM UTC."
     },
     {
       "op": "gt",
       "description": "is after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2020-12-25T04:45:00.00+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "lt" },
+        "match": "2020-12-25T04:45:00.00+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is after December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "lt",
       "description": "is before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"2021-05-25T09:30:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "lt" },
+        "match": "2021-05-25T09:30:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is prior to May 25, 2021 9:30:00 AM UTC."
     },
     {
       "op": "gte",
       "description": "is on or after",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"2019-06-14T18:16:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "gte" },
+        "match": "2019-06-14T18:16:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is exactly at or after June 14, 2019 at 6:16 PM UTC"
     },
     {
       "op": "lte",
       "description": "is on or before",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"2020-12-25T04:45:00.000+00:00\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "lte" },
+        "match": "2020-12-25T04:45:00.000+00:00",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is exactly at or before December 25, 2020 at 04:45:00 UTC."
     },
     {
       "op": "relative_gt",
       "description": "is in the past",
-      "example": "{\n  \"propertyId\": \"last_purchase_date\", \n  \"operation\": {\"op\": \"relative_gt\" },\n  \"relativeMatchNumber\": \"60\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "last_purchase_date",
+        "operation": { "op": "relative_gt" },
+        "relativeMatchNumber": "60",
+        "relativeMatchUnit": "days",
+        "type": "date"
+      },
       "caption": "All profiles whose most recent purchase is within the last 60 days"
     },
     {
       "op": "relative_lt",
       "description": "is in the future",
-      "example": "{\n  \"propertyId\": \"subscription_ends\", \n  \"operation\": {\"op\": \"relative_lt\" },\n  \"relativeMatchNumber\": \"30\",\n  \"relativeMatchUnit\": \"days\"\n  \"type\": \"date\" \n}",
+      "example": {
+        "propertyId": "subscription_ends",
+        "operation": { "op": "relative_lt" },
+        "relativeMatchNumber": "30",
+        "relativeMatchUnit": "days",
+        "type": "date"
+      },
       "caption": "All profiles whose subscription ends within the next 30 days"
     }
   ],
@@ -91,55 +153,83 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"exists\" },\n \n}",
+      "example": { "propertyId": "email", "operation": { "op": "exists" } },
       "caption": "All profiles with an email address listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notExists\" },\n \n}",
+      "example": { "propertyId": "email", "operation": { "op": "notExists" } },
       "caption": "All profiles without an email address listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "eq" },
+        "match": "hello@grouparoo.com"
+      },
       "caption": "All profiles with an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"hello@grouparoo.com\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "ne" },
+        "match": "hello@grouparoo.com"
+      },
       "caption": "All profiles without an email address exactly equal to hello@grouparoo.com."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%smith%\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "like" },
+        "match": "%smith%"
+      },
       "caption": "All profiles with an email address containing smith (case sensitive)."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%smith%\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "notLike" },
+        "match": "%smith%"
+      },
       "caption": "All profiles without an email address containing smith (case sensitive)."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"test\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "startsWith" },
+        "match": "test"
+      },
       "caption": "All profiles with an email address starting with \"test\" (case sensitive)."
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"grouparoo.com\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "endsWith" },
+        "match": "grouparoo.com"
+      },
       "caption": "All profiles with an email address ending with \"@grouparoo.com\" (case sensitive)."
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"email\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\",\n}",
+      "example": {
+        "propertyId": "email",
+        "operation": { "op": "substring" },
+        "match": "grouparoo"
+      },
       "caption": "All profiles with an email address containing \"grouparoo\"."
     }
   ],
@@ -147,49 +237,73 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": { "propertyId": "ltv", "operation": { "op": "exists" } },
       "caption": "All profiles with an LTV value."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": { "propertyId": "ltv", "operation": { "op": "notExists" } },
       "caption": "All profiles without an LTV value."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"eq\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "eq" },
+        "match": "113932.97"
+      },
       "caption": "All profiles with an LTV of exactly $113,932.97."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"ne\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "ne" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of exactly $113,932.97."
     },
     {
       "op": "gt",
       "description": "is greater than",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gt\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "gt" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of greater than $113,932.97."
     },
     {
       "op": "lt",
       "description": "is less than",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lt\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "lt" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of less than $113,932.97."
     },
     {
       "op": "gte",
       "description": "is greater than or equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"gte\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "gte" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of exactly $113,932.97. or more"
     },
     {
       "op": "lte",
       "description": "is less than or equal to",
-      "example": "{\n  \"propertyId\": \"ltv\", \n  \"operation\": {\"op\": \"lte\" }\n  \"match\": \"113932.97\"\n}",
+      "example": {
+        "propertyId": "ltv",
+        "operation": { "op": "lte" },
+        "match": "113932.97"
+      },
       "caption": "All profiles without an LTV of exactly $113,932.97. or less"
     }
   ],
@@ -197,49 +311,73 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": { "propertyId": "visits", "operation": { "op": "notExists" } },
       "caption": "All profiles with any value in the \"visits\" field."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"notExists\" }\n}",
+      "example": { "propertyId": "visits", "operation": { "op": "notExists" } },
       "caption": "All profiles with an empty \"visits\" field."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "eq" },
+        "match": "6"
+      },
       "caption": "All profiles with exactly six visits."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "ne" },
+        "match": "6"
+      },
       "caption": "All profiles with any number of visits except six."
     },
     {
       "op": "gt",
       "description": "is greater than",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gt\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "gt" },
+        "match": "6"
+      },
       "caption": "All profiles with more than six visits."
     },
     {
       "op": "lt",
       "description": "is less than",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "ne" },
+        "match": "6"
+      },
       "caption": "All profiles with less than six visits."
     },
     {
       "op": "gte",
       "description": "is greater than or equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"gte\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "gte" },
+        "match": "6"
+      },
       "caption": "All profiles with six or more visits."
     },
     {
       "op": "lte",
       "description": "is less than or equal to",
-      "example": "{\n  \"propertyId\": \"visits\", \n  \"operation\": {\"op\": \"lte\" },\n  \"match\": \"6\"\n}",
+      "example": {
+        "propertyId": "visits",
+        "operation": { "op": "lte" },
+        "match": "6"
+      },
       "caption": "All profiles with 6 or fewer visits."
     }
   ],
@@ -247,55 +385,83 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": { "propertyId": "phone", "operation": { "op": "exists" } },
       "caption": "All profiles with a phone number listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "example": { "propertyId": "phone", "operation": { "op": "notExists" } },
       "caption": "All profiles without a phone number listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"+1-555-555-5555\" }",
-      "caption": "All profiles with a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "eq" },
+        "match": "+1-555-555-5555"
+      },
+      "caption": "All profiles with a phone number of +1-555-555-5555."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"+1-555-555-5555\" }",
-      "caption": "All profiles without a phone number of +1-555-555-5555.  Note that the format you enter your match term in must exactly match the format used in your data set."
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "ne" },
+        "match": "+1-555-555-5555"
+      },
+      "caption": "All profiles without a phone number of +1-555-555-5555."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%780%\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "like" },
+        "match": "%780%"
+      },
       "caption": "All profiles with a phone number containing 780."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"%780%\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "notLike" },
+        "match": "%780%"
+      },
       "caption": "All profiles without a phone number containing 780."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"+1\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "startsWith" },
+        "match": "+1"
+      },
       "caption": "All profiles with a phone number starting with +1."
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "startsWith" },
+        "match": "80"
+      },
       "caption": "All profiles with a phone number ending with 80."
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"phone\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"80\" }",
+      "example": {
+        "propertyId": "phone",
+        "operation": { "op": "startsWith" },
+        "match": "80"
+      },
       "caption": "All profiles with a phone number containing the substring 80."
     }
   ],
@@ -303,55 +469,86 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": { "propertyId": "lastName", "operation": { "op": "exists" } },
       "caption": "All profiles with a last name listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles without a last name listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"Ramirez\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "eq" },
+        "match": "Ramirez"
+      },
       "caption": "All profiles with a last name of exactly Ramirez."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"Ramirez\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "ne" },
+        "match": "Ramirez"
+      },
       "caption": "All profiles without a last name of exactly Ramirez."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"__m%\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "like" },
+        "match": "__m%"
+      },
       "caption": "All profiles with a last name that has a third letter of m."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"notLike\" },\n  \"match\": \"__m%\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "notLike" },
+        "match": "__m%"
+      },
       "caption": "All profiles without a last name that has a third letter of m."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"Mc\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "startsWith" },
+        "match": "Mc"
+      },
       "caption": "All profiles with a last name starting with Mc (case sensitive)"
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"endsWith\" },\n  \"match\": \"son\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "endsWith" },
+        "match": "son"
+      },
       "caption": "All profiles with a last name ending with son (case sensitive)."
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"lastName\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"al\" }",
+      "example": {
+        "propertyId": "lastName",
+        "operation": { "op": "substring" },
+        "match": "al"
+      },
       "caption": "All profiles with a last name containing al (case sensitive)."
     }
   ],
@@ -359,55 +556,89 @@
     {
       "op": "exists",
       "description": "exists with any value",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"exists\" },\n}",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "exists" }
+      },
       "caption": "All profiles with a company URL listed."
     },
     {
       "op": "notExists",
       "description": "does not exist",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"notExists\" },\n}",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "notExists" }
+      },
       "caption": "All profiles without a company URL listed."
     },
     {
       "op": "eq",
       "description": "is equal to",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"eq\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "eq" },
+        "match": "https://www.grouparoo.com"
+      },
       "caption": "All profiles with a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "ne",
       "description": "is not equal to",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"ne\" },\n  \"match\": \"https://www.grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "ne" },
+        "match": "https://www.grouparoo.com"
+      },
       "caption": "All profiles without a company URL exactly equal to https://www.grouparoo.com."
     },
     {
       "op": "like",
       "description": "is like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "like" },
+        "match": "%grouparoo.com"
+      },
       "caption": "All profiles with a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "notLike",
       "description": "is not like (case sensitive)",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"like\" },\n  \"match\": \"%grouparoo.com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "like" },
+        "match": "%grouparoo.com"
+      },
       "caption": "All profiles without a company URL containing anything and then grouparoo.com (case sensitive)."
     },
     {
       "op": "startsWith",
       "description": "starts with",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \"https\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "startsWith" },
+        "match": "https"
+      },
       "caption": "All profiles with a company URL starting with https (case sensitive)."
     },
     {
       "op": "endsWith",
       "description": "ends with",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"startsWith\" },\n  \"match\": \".com\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "startsWith" },
+        "match": ".com"
+      },
       "caption": "All profiles with a company URL ending with .com (case sensitive)"
     },
     {
       "op": "substring",
       "description": "includes the string",
-      "example": "{\n  \"propertyId\": \"company_url\", \n  \"operation\": {\"op\": \"substring\" },\n  \"match\": \"grouparoo\" }",
+      "example": {
+        "propertyId": "company_url",
+        "operation": { "op": "substring" },
+        "match": "grouparoo"
+      },
       "caption": "All profiles with a company URL containing grouparoo (case sensitive)"
     }
   ],

--- a/pages/docs/config/groups/community.mdx
+++ b/pages/docs/config/groups/community.mdx
@@ -35,15 +35,15 @@ exports.default = async function buildConfig() {
 };
 ```
 
-which you can customize with rules:
+which you can customize with rules such as:
 
 ```js
 exports.default = async function buildConfig() {
   return [
     {
       class: "group",
-      id: "new_high_value_customers",
-      name: "New High Value Customers",
+      id: "recent_high_value_customers",
+      name: "Recent High Value Customers",
       type: "calculated",
       rules: [
         {

--- a/pages/docs/config/groups/community.mdx
+++ b/pages/docs/config/groups/community.mdx
@@ -87,7 +87,7 @@ Configuring a Calculated Group is all about adding Rules to the group. A Rule is
 
 Available operations depends on both the _type_ of Property and the underlying Grouparoo database (SQLite vs. Postgres). See below for a list of rules. (If in doubt, choose Postgres.)
 
-Note you can use SQL wildcard characters (%, \_, [], ^, -) in your group rule match values as appropriate and necessary.
+Note you can use SQL wildcard characters (%, \_, [ ], ^, -) in your group rule match values as appropriate and necessary.
 
 <RuleOpsTable />
 

--- a/pages/docs/config/groups/community.mdx
+++ b/pages/docs/config/groups/community.mdx
@@ -17,23 +17,67 @@ To generate a new Calculated Group for your Grouparoo application, run [the `gen
 
     grouparoo generate group:calculated all_emails
 
-Note here that `all_emails` is the ID for the Group. An ID is always required when generating a config object.
+Note here that `new_high_value_customers` is the ID for the Group. An ID is always required when generating a config object.
 
-This command will generate a file in your application directory at `config/groups/all_emails.js` that looks something like this:
+This command will generate a file in your application directory at `config/groups/new_high_value_customers.js` that looks something like this:
 
 ```js
 exports.default = async function buildConfig() {
   return [
     {
       class: "group",
-      id: "all_emails",
-      name: "all_emails",
+      id: "new_high_value_customers",
+      name: "New High Value Customers",
       type: "calculated",
       rules: [],
     },
   ];
 };
 ```
+
+which you can customize with rules:
+
+```js
+exports.default = async function buildConfig() {
+  return [
+    {
+      class: "group",
+      id: "new_high_value_customers",
+      name: "New High Value Customers",
+      type: "calculated",
+      rules: [
+        {
+          propertyId: "email",
+          operation: { op: "exists" },
+        },
+        {
+          propertyId: "email",
+          operation: { op: "notILike" },
+          match: "%grouparoo.com",
+        },
+        {
+          propertyId: "last_purchase_date",
+          operation: { op: "relative_gt" },
+          relativeMatch: "15",
+          relativeMatchUnit: "days",
+        },
+        {
+          propertyId: "ltv",
+          operation: { op: "gt" },
+          match: "3000",
+        },
+        {
+          propertyId: "subscribed",
+          operation: { op: "eq" },
+          match: "true",
+        },
+      ],
+    },
+  ];
+};
+```
+
+This group would contain profiles with an email address that is not `@grouparoo.com` that have made a purchase in the last 15 days, have a lifetime value over $3000, and are subscribed to our newsletter.
 
 More info this below.
 
@@ -42,6 +86,8 @@ More info this below.
 Configuring a Calculated Group is all about adding Rules to the group. A Rule is some logical operator to filter Properties. A profile must match every Rule to be included in the Group.
 
 Available operations depends on both the _type_ of Property and the underlying Grouparoo database (SQLite vs. Postgres). See below for a list of rules. (If in doubt, choose Postgres.)
+
+Note you can use SQL wildcard characters (%, \_, [], ^, -) in your group rule match values as appropriate and necessary.
 
 <RuleOpsTable />
 

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -306,6 +306,30 @@ hr {
   }
 }
 
+//docs group rules tables:
+.table-responsive::-webkit-scrollbar {
+  -webkit-appearance: none;
+}
+
+.table-responsive::-webkit-scrollbar:vertical {
+  width: 12px;
+}
+
+.table-responsive::-webkit-scrollbar:horizontal {
+  height: 12px;
+}
+
+.table-responsive::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 10px;
+  border: 2px solid #ffffff;
+}
+
+.table-responsive::-webkit-scrollbar-track {
+  border-radius: 10px;
+  background-color: #ffffff;
+}
+
 // -- Code --
 // @import url(/css/prism.css);
 


### PR DESCRIPTION
- Added examples for all group rule types
- Adjusted layout to increase responsiveness
- Removed `build_static_refs` from core in [this PR](https://github.com/grouparoo/grouparoo/pull/1889) as we no longer want these .json files auto generated

BEFORE on mobile:  
![Screen Shot 2021-06-02 at 10 38 06 AM](https://user-images.githubusercontent.com/63751206/120527022-b686ec00-c38e-11eb-9b5d-6f695f3f134c.png)

AFTER:
desktop/laptop/ipad pro
![Screen Shot 2021-06-02 at 10 34 33 AM](https://user-images.githubusercontent.com/63751206/120527085-ca325280-c38e-11eb-8544-966fecf94720.png)

mobile/ipad
![Screen Shot 2021-06-02 at 10 47 25 AM](https://user-images.githubusercontent.com/63751206/120528145-f9958f00-c38f-11eb-80d2-e55e6cb35b2a.png)

Some longer code lines (a few date rules) still require horizontal scrolling on narrow phone screens, but I'm hesitant to decrease the font size on mobile.  I think it's still an improvement.

![Screen Shot 2021-06-02 at 10 47 09 AM](https://user-images.githubusercontent.com/63751206/120528157-fb5f5280-c38f-11eb-9bf0-f16b6ba17f88.png)