### PR TITLE
Revert "`head_ref` does not work in forks"

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,6 +10,8 @@ jobs:
         run: |
           echo ${{github.actor}}
       - uses: actions/checkout@master
+        with:
+          ref: ${{ github.head_ref }}
       - name: Calculate performance
         run: |
           ./scripts/performance_action

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -7,10 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'grouparoo/www.grouparoo.com' }}
     steps:
-      - name: echo actor
-        run: |
-          echo ${{github.actor}}
       - uses: actions/checkout@master
+        with:
+          ref: ${{ github.head_ref }}
       - name: Update files
         run: |
           ./scripts/github_action


### PR DESCRIPTION
Reverts grouparoo/www.grouparoo.com#511

This IS needed to the auto-update action knows what branch to push things to.  

This will bring back problems for people who try to contribute on external forks, but we'll have to find another solution