### PR TITLE
Use webpack v5

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,11 +5,6 @@ module.exports = {
     ROBOTS_DISABLED: process.env.ROBOTS_DISABLED,
     GOOGLE_ANALYTICS_TRACKING_ID: process.env.GOOGLE_ANALYTICS_TRACKING_ID,
   },
-  webpack: (config) => {
-    config.module.rules.push({ test: /\.md$/, use: "raw-loader" });
-    config.module.rules.push({ test: /\.excalidraw$/, use: "raw-loader" });
-    return config;
-  },
   async rewrites() {
     return [];
   },

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -13,12 +13,13 @@ import externalLinks from "remark-external-links";
 import { titleize } from "../utils/inflectors";
 
 const dirname = __dirname;
-let rootDir;
+let rootDir: string;
 if (!dirname || dirname === "/") {
   rootDir = path.resolve(path.join(process.cwd()));
 } else {
   rootDir = path.resolve(path.join(__dirname, "..", ".."));
 }
+rootDir = rootDir.split(`${path.sep}.next`)[0];
 
 const pagesDir = path.join(rootDir, "pages");
 

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -17,7 +17,7 @@ let rootDir: string;
 if (!dirname || dirname === "/") {
   rootDir = path.resolve(path.join(process.cwd()));
 } else {
-  rootDir = path.resolve(path.join(__dirname, "..", ".."));
+  rootDir = path.resolve(path.join(__dirname, ".."));
 }
 rootDir = rootDir.split(`${path.sep}.next`)[0];
 

--- a/utils/mdxUtils.ts
+++ b/utils/mdxUtils.ts
@@ -17,8 +17,9 @@ let rootDir;
 if (!dirname || dirname === "/") {
   rootDir = path.resolve(path.join(process.cwd()));
 } else {
-  rootDir = path.resolve(path.join(__dirname, ".."));
+  rootDir = path.resolve(path.join(__dirname, "..", ".."));
 }
+
 const pagesDir = path.join(rootDir, "pages");
 
 export const mdxOptions = {


### PR DESCRIPTION
Here's why Webpack 5 + Next is better https://nextjs.org/docs/messages/webpack5

Webpack 5 seems to have only updated the root path for the application (to somewhere within the `.next` folder), so the only change was to our MDX loader paths. 

Our custom webpack loaders didn't seem to be doing anything, as we never server a MD file or excalidraw file though the site