### PR TITLE
error on `/meet` form if no email

### DIFF
--- a/pages/meet.tsx
+++ b/pages/meet.tsx
@@ -13,13 +13,18 @@ interface FormError {
   generic: string;
 }
 export default function Meet() {
-  const { handleSubmit, register } = useForm();
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm();
   const { query } = useRouter();
   const [loading, setLoading] = useState(false);
   const [requested, setRequested] = useState(false);
   const [error, setError] = useState<FormError>({ email: null, generic: null });
 
   const errorHandler = new ErrorHandler();
+
   errorHandler.subscribe("result", (e) => {
     const error: FormError = { email: null, generic: null };
     const message = e?.error?.message || e?.message || e.toString();
@@ -176,6 +181,11 @@ export default function Meet() {
                         disabled={disabled}
                       />
                       <Error message={error.email} />
+                      {errors.email && (
+                        <small style={{ color: "red" }}>
+                          A valid email is required.
+                        </small>
+                      )}
                     </Form.Group>
                     <Form.Group>
                       <Form.Label>Company Name</Form.Label>

--- a/pages/meet.tsx
+++ b/pages/meet.tsx
@@ -147,7 +147,7 @@ export default function Meet() {
             <Error message={error.generic} />
             <Container className="bg-light p-4 mt-4 mt-md-0">
               <h3 className="mx-auto text-center">Schedule a 30 minute demo</h3>
-              <Form id="form" onSubmit={handleSubmit(onSubmit)}>
+              <Form id="form" onSubmit={handleSubmit(onSubmit)} noValidate>
                 {!requested ? (
                   <>
                     {" "}


### PR DESCRIPTION
Previously, React Hook Form would block form submission with a missing email, but no error would display (because the errors were wired to come from the server).  I've added React Hook Form error handling for the email field similar to on `/trial`.


Now, users get an error: 
![Screen Shot 2021-06-17 at 3 19 36 PM](https://user-images.githubusercontent.com/63751206/122479137-707d7b00-cf7f-11eb-9804-097e285d5de0.png)
