### PR TITLE
Integrations links in header and footer update

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -93,159 +93,171 @@ export default function Footer() {
   return (
     <footer className="footer py-5">
       <Container>
-        <Row>
-          <Col md={3} className="d-none d-lg-block">
+        <Row className="d-flex justify-content-between">
+          <Col lg={3} className="d-none d-lg-block">
             <LogoAndSocialLinks router={router} />
           </Col>
-          <Col md={9}>
+          <Col lg={9}>
             <Row>
-              <Col>
-                <strong>Use Cases</strong>
-                <br />
-                <Link href="/solutions/engineers">
-                  <a>Grouparoo for Engineers</a>
-                </Link>
-                <br />
-                <Link href="/solutions/marketers">
-                  <a>Grouparoo for Marketers</a>
-                </Link>
-                <br />
-                <Link href="/solutions/healthcare">
-                  <a>Healthcare</a>
-                </Link>
-                <br />
-                <Link href="/solutions/education">
-                  <a>Education</a>
-                </Link>
-                <br />
-                <Link href="/solutions/segment-alternative">
-                  <a>Segment Alternative</a>
-                </Link>
-                <br />
-                <Link href="/solutions/census-alternative">
-                  <a>Census Alternative</a>
-                </Link>
-                <br />
-                <Link href="/solutions/hightouch-alternative">
-                  <a>Hightouch Alternative</a>
-                </Link>
-                <br />
+              <Col className="d-none d-md-inline-block col-md-1" />
 
-                <Link href="/solutions/reverse-etl">
-                  <a>Reverse ETL</a>
-                </Link>
-                <br />
+              <Col className="col-6 col-md-3 pb-2 px-3 ">
+                <div className="pl-1">
+                  <strong>Use Cases</strong>
+                  <br />
+                  <Link href="/solutions/engineers">
+                    <a>Grouparoo for Engineers</a>
+                  </Link>
+                  <br />
+                  <Link href="/solutions/marketers">
+                    <a>Grouparoo for Marketers</a>
+                  </Link>
+                  <br />
+                  <Link href="/solutions/healthcare">
+                    <a>Healthcare</a>
+                  </Link>
+                  <br />
+                  <Link href="/solutions/education">
+                    <a>Education</a>
+                  </Link>
+                  <br />
+                  <Link href="/solutions/segment-alternative">
+                    <a>Segment Alternative</a>
+                  </Link>
+                  <br />
+                  <Link href="/solutions/census-alternative">
+                    <a>Census Alternative</a>
+                  </Link>
+                  <br />
+                  <Link href="/solutions/hightouch-alternative">
+                    <a>Hightouch Alternative</a>
+                  </Link>
+                  <br />
 
-                <Link href="/solutions/modern-data-stack">
-                  <a>Modern Data Stack</a>
-                </Link>
+                  <Link href="/solutions/reverse-etl">
+                    <a>Reverse ETL</a>
+                  </Link>
+                  <br />
+
+                  <Link href="/solutions/modern-data-stack">
+                    <a>Modern Data Stack</a>
+                  </Link>
+                </div>
+
+                <hr className="d-md-none mx-auto border-light border-top-0 m-2" />
               </Col>
-              <Col>
-                <strong>Integrations</strong>
-                <br />
-                <Link href="/integrations/destinations/salesforce">
-                  <a>Salesforce Data Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/destinations/zendesk">
-                  <a>Zendesk Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/destinations/marketo">
-                  <a>Marketo Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/destinations/mailchimp">
-                  <a>Mailchimp Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/destinations/hubspot">
-                  <a>Hubspot Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/destinations/iterable">
-                  <a>Iterable Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/sources/bigquery">
-                  <a>Bigquery Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/sources/snowflake">
-                  <a>Snowflake Integration</a>
-                </Link>
-                <br />
-                <Link href="/integrations/sources/redshift">
-                  <a>Snowflake Integration</a>
-                </Link>
-                <br />
+              <Col className="col-6 col-md-3 pb-2 px-3">
+                <div className="pl-1">
+                  <strong>Integrations</strong>
+                  <br />
+                  <Link href="/integrations/destinations/salesforce">
+                    <a>Salesforce Data Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/destinations/zendesk">
+                    <a>Zendesk Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/destinations/marketo">
+                    <a>Marketo Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/destinations/mailchimp">
+                    <a>Mailchimp Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/destinations/hubspot">
+                    <a>Hubspot Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/destinations/iterable">
+                    <a>Iterable Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/sources/bigquery">
+                    <a>Bigquery Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/sources/snowflake">
+                    <a>Snowflake Integration</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations/sources/redshift">
+                    <a>Snowflake Integration</a>
+                  </Link>
+                  <br />
+                </div>
+                <hr className="d-md-none mx-auto border-light border-top-0 m-2" />
               </Col>
-              <Col>
-                <strong>Product</strong>
-                <br />
-                <Link href="/docs">
-                  <a>Docs</a>
-                </Link>
-                <br />
-                <Link href="/pricing">
-                  <a>Pricing</a>
-                </Link>
-                <br />
-                <Link href="/integrations">
-                  <a>Integrations</a>
-                </Link>
-                <br />
-                <Link href="/whats-new">
-                  <a>What's New</a>
-                </Link>
-                <br />
-                <Link href="/docs/community">
-                  <a>Community</a>
-                </Link>
-                <br />
-                <a
-                  target="_blank"
-                  href="https://github.com/grouparoo/grouparoo"
-                  rel="noreferrer"
-                >
-                  Github
-                </a>
+              <Col className="col-6 col-md-2 pb-2 px-3">
+                <div className="pl-1">
+                  <strong>Product</strong>
+                  <br />
+                  <Link href="/docs">
+                    <a>Docs</a>
+                  </Link>
+                  <br />
+                  <Link href="/pricing">
+                    <a>Pricing</a>
+                  </Link>
+                  <br />
+                  <Link href="/integrations">
+                    <a>Integrations</a>
+                  </Link>
+                  <br />
+                  <Link href="/whats-new">
+                    <a>What's New</a>
+                  </Link>
+                  <br />
+                  <Link href="/docs/community">
+                    <a>Community</a>
+                  </Link>
+                  <br />
+                  <a
+                    target="_blank"
+                    href="https://github.com/grouparoo/grouparoo"
+                    rel="noreferrer"
+                  >
+                    Github
+                  </a>
+                </div>
               </Col>
-              <Col>
-                <strong>Company</strong>
-                <br />
-                <Link href="/about">
-                  <a>About Us</a>
-                </Link>
-                <br />
-                <Link href="/blog">
-                  <a>Blog</a>
-                </Link>
-                <br />
-                <Link href="/docs/support">
-                  <a>Support</a>
-                </Link>
-                <br />
-                <Link href="/meet">
-                  <a>Contact Us</a>
-                </Link>
-                <br />
-                <Link href="/about#careers">
-                  <a>Careers</a>
-                </Link>
-                <br />
-                <Link href="/legal/privacy">
-                  <a>Privacy Policy</a>
-                </Link>
+              <Col className="col-6 col-md-2 pb-2 px-3">
+                <div className="pl-1">
+                  <strong>Company</strong>
+                  <br />
+                  <Link href="/about">
+                    <a>About Us</a>
+                  </Link>
+                  <br />
+                  <Link href="/blog">
+                    <a>Blog</a>
+                  </Link>
+                  <br />
+                  <Link href="/docs/support">
+                    <a>Support</a>
+                  </Link>
+                  <br />
+                  <Link href="/meet">
+                    <a>Contact Us</a>
+                  </Link>
+                  <br />
+                  <Link href="/about#careers">
+                    <a>Careers</a>
+                  </Link>
+                  <br />
+                  <Link href="/legal/privacy">
+                    <a>Privacy Policy</a>
+                  </Link>
+                </div>
               </Col>
+              <Col className="d-none d-md-inline-block col-md-1" />
             </Row>
           </Col>
         </Row>
 
         <Row className="d-lg-none">
-          <Col
-            style={{ textAlign: "center", paddingTop: 50, paddingBottom: 50 }}
-          >
+          <Col className="text-center pb-4 pt-5">
             <LogoAndSocialLinks router={router} />
           </Col>
         </Row>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -94,10 +94,10 @@ export default function Footer() {
     <footer className="footer py-5">
       <Container>
         <Row>
-          <Col md={6} className="d-none d-lg-block">
+          <Col md={3} className="d-none d-lg-block">
             <LogoAndSocialLinks router={router} />
           </Col>
-          <Col md={6}>
+          <Col md={9}>
             <Row>
               <Col>
                 <strong>Use Cases</strong>
@@ -139,6 +139,46 @@ export default function Footer() {
                 <Link href="/solutions/modern-data-stack">
                   <a>Modern Data Stack</a>
                 </Link>
+              </Col>
+              <Col>
+                <strong>Integrations</strong>
+                <br />
+                <Link href="/integrations/destinations/salesforce">
+                  <a>Salesforce Data Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/destinations/zendesk">
+                  <a>Zendesk Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/destinations/marketo">
+                  <a>Marketo Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/destinations/mailchimp">
+                  <a>Mailchimp Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/destinations/hubspot">
+                  <a>Hubspot Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/destinations/iterable">
+                  <a>Iterable Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/sources/bigquery">
+                  <a>Bigquery Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/sources/snowflake">
+                  <a>Snowflake Integration</a>
+                </Link>
+                <br />
+                <Link href="/integrations/sources/redshift">
+                  <a>Snowflake Integration</a>
+                </Link>
+                <br />
               </Col>
               <Col>
                 <strong>Product</strong>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -53,21 +53,21 @@ export default function Navigation() {
                       <Dropdown.Item>
                         <Link href="/integrations/sources/snowflake">
                           <a className="nav-link" role="button">
-                            Snowflake
+                            Snowflake Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Item>
                         <Link href="/integrations/sources/postgres">
                           <a className="nav-link" role="button">
-                            Postgres
+                            Postgres Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Item>
                         <Link href="/integrations/sources/mysql">
                           <a className="nav-link" role="button">
-                            MySQL
+                            MySQL Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
@@ -98,21 +98,21 @@ export default function Navigation() {
                       <Dropdown.Item>
                         <Link href="/integrations/destinations/salesforce">
                           <a className="nav-link" role="button">
-                            Salesforce
+                            Salesforce Data Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Item>
                         <Link href="/integrations/destinations/marketo">
                           <a className="nav-link" role="button">
-                            Marketo
+                            Marketo Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Item>
                         <Link href="/integrations/destinations/zendesk">
                           <a className="nav-link" role="button">
-                            Zendesk
+                            Zendesk Integration
                           </a>
                         </Link>
                       </Dropdown.Item>

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -103,7 +103,7 @@ header {
     padding-bottom: 1em;
   }
   .integrationsNav {
-    width: 18em;
+    width: 28em;
     padding-bottom: 1em;
   }
 }


### PR DESCRIPTION
First round -- I went with the exact phrasing that the SEO firm recommended ("data integration" for Salesforce and "integration" for all others) and I don't hate it as much as I thought I would visually.

Though from a user experience perspective, I would expect different phrasing to mean different behavior, so that may be confusing.

Victorious suggested this change because it will make our anchor texts match the intention for those pages.  The reason they are different is that people search for "Salesforce data integration" much more than "Salesforce integration", but the others are vice versa.

Open to alternatives, or to giving this a try and trusting it will help!