### PR TITLE
Noindexed tag and author pages, whats new pages

### DIFF
--- a/components/seo.tsx
+++ b/components/seo.tsx
@@ -37,6 +37,7 @@ const SEO = ({
   twitterAuthor,
   twitterCard,
   path,
+  noIndex = false,
 }: {
   canonical?: boolean;
   description?: string;
@@ -45,6 +46,7 @@ const SEO = ({
   twitterAuthor?: string;
   twitterCard?: string;
   path: string;
+  noIndex?: boolean;
 }) => {
   if (!path || !title) {
     console.error(`path and title are required for SEO component.`);
@@ -76,7 +78,7 @@ const SEO = ({
         />
         <meta name="twitter:site" content="@grouparoo" />
         <meta name="twitter:creator" content={twitterAuthor || "@grouparoo"} />
-
+        {noIndex ? <meta name="robots" content="noindex" /> : null}
         <meta property="og:title" content={title} />
         <meta property="og:url" content={url} />
       </Head>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -76,6 +76,7 @@ export default function BlogIndex({ pageProps }) {
           type="application/rss+xml"
           href="https://www.grouparoo.com/feeds/blog.xml"
         />
+        <meta name="robots" content="noindex" />
       </Head>
 
       <Container>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -76,7 +76,7 @@ export default function BlogIndex({ pageProps }) {
           type="application/rss+xml"
           href="https://www.grouparoo.com/feeds/blog.xml"
         />
-        <meta name="robots" content="noindex" />
+        {category || author ? <meta name="robots" content="noindex" /> : null}
       </Head>
 
       <Container>

--- a/pages/whats-new/[note].tsx
+++ b/pages/whats-new/[note].tsx
@@ -25,6 +25,7 @@ export default function ReleaseNotePage({ pageProps, ...props }) {
         description={feature.description}
         twitterCard={feature.twitterCard || "summary"}
         image={feature.image}
+        noIndex={true}
       />
 
       <Container className="releasePage">

--- a/pages/whats-new/index.tsx
+++ b/pages/whats-new/index.tsx
@@ -33,6 +33,7 @@ export default function ReleaseIndex({ pageProps }) {
           type="application/rss+xml"
           href="https://www.grouparoo.com/feeds/whatsnew.xml"
         />
+        <meta name="robots" content="noindex" />
       </Head>
 
       <Container className="releasePage">

--- a/pages/whats-new/index.tsx
+++ b/pages/whats-new/index.tsx
@@ -33,7 +33,6 @@ export default function ReleaseIndex({ pageProps }) {
           type="application/rss+xml"
           href="https://www.grouparoo.com/feeds/whatsnew.xml"
         />
-        <meta name="robots" content="noindex" />
       </Head>
 
       <Container className="releasePage">


### PR DESCRIPTION
Noindexing these pages means they will not be crawled and will not show up in search results.

The reasoning behind this is that the thin content on them drags the other pages down.  Noindexing them will boost the other pages that we want people to be directed to.

Pages affected: 
- feeds by author and tag
- individual what's new posts

Pages unaffected:
- what's new feed
- blog feed
- blog posts