### PR TITLE
only send gtag if conversion successful

### DIFF
--- a/pages/meet.tsx
+++ b/pages/meet.tsx
@@ -74,19 +74,20 @@ export default function Meet() {
     data.medium = medium;
     data.campaign = campaign;
 
-    if (isBrowser() && globalThis?.gtag) {
-      globalThis.gtag("event", "conversion", {
-        send_to: GoogleAdsDemoID,
-        event_callback: () => {},
-      });
-      globalThis.gtag("event", "demo-request", {
-        event_category: "conversion",
-        event_callback: () => {},
-      });
-    }
-
     const response = await execApi("post", `/api/v1/demo-request`, data);
-    if (response?.demoRequest) setRequested(true);
+    if (response?.demoRequest) {
+      setRequested(true);
+      if (isBrowser() && globalThis?.gtag) {
+        globalThis.gtag("event", "conversion", {
+          send_to: GoogleAdsDemoID,
+          event_callback: () => {},
+        });
+        globalThis.gtag("event", "demo-request", {
+          event_category: "conversion",
+          event_callback: () => {},
+        });
+      }
+    }
     setLoading(false);
   };
 

--- a/pages/trial.tsx
+++ b/pages/trial.tsx
@@ -110,20 +110,20 @@ export default function Trial({ props }) {
     data.companyWebsite = data.companyWebsite.toLowerCase();
     data.subdomain = data.subdomain.toLowerCase();
 
-    if (isBrowser() && globalThis?.gtag) {
-      globalThis.gtag("event", "conversion", {
-        send_to: GoogleAdsTrialConversion,
-        event_callback: () => {},
-      });
-      globalThis.gtag("event", "trial-request", {
-        event_category: "conversion",
-        event_callback: () => {},
-      });
-    }
-
     const response = await execApi("post", `/api/v1/trial-request`, data);
     if (response?.trialRequest) {
       setRegistered(true);
+
+      if (isBrowser() && globalThis?.gtag) {
+        globalThis.gtag("event", "conversion", {
+          send_to: GoogleAdsTrialConversion,
+          event_callback: () => {},
+        });
+        globalThis.gtag("event", "trial-request", {
+          event_category: "conversion",
+          event_callback: () => {},
+        });
+      }
     }
     setLoading(false);
   };


### PR DESCRIPTION
Per discussion in planning this morning, this PR moves the event tag trigger to only happen when there is a successful response from the server for a demo or trial request.