### PR TITLE
add page_path to ga tag

### DIFF
--- a/components/googleAnalytics.tsx
+++ b/components/googleAnalytics.tsx
@@ -11,7 +11,7 @@ function GoogleAnalytics() {
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
-gtag('config', '${GoogleAnalyticsTrackingID}');
+gtag('config', '${GoogleAnalyticsTrackingID}', {page_path: window.location.pathname});
 `;
 
     const script = document.createElement("script");

--- a/components/googleAnalytics.tsx
+++ b/components/googleAnalytics.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 
 const GoogleAnalyticsTrackingID = process.env.GOOGLE_ANALYTICS_TRACKING_ID;
 
-function GoogleAnalytics() {
+export function GoogleAnalytics() {
   useEffect(() => {
     if (!GoogleAnalyticsTrackingID) return;
 
@@ -34,4 +34,8 @@ gtag('config', '${GoogleAnalyticsTrackingID}', {page_path: window.location.pathn
   );
 }
 
-export default GoogleAnalytics;
+export function googleAnalyticsPageView(url: string) {
+  if (globalThis?.gtag) {
+    globalThis.gtag("config", GoogleAnalyticsTrackingID, { page_path: url });
+  }
+}

--- a/components/layouts/floating.tsx
+++ b/components/layouts/floating.tsx
@@ -1,6 +1,6 @@
 import { Children, cloneElement } from "react";
 import Head from "next/head";
-import GoogleAnalytics from "../googleAnalytics";
+import { GoogleAnalytics } from "../googleAnalytics";
 import AdConversionScript from "../adConversionsScript";
 import { Container } from "react-bootstrap";
 

--- a/components/layouts/main.tsx
+++ b/components/layouts/main.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, Children, cloneElement } from "react";
 import Head from "next/head";
-import GoogleAnalytics from "../googleAnalytics";
+import { GoogleAnalytics } from "../googleAnalytics";
 import AdConversionScript from "../adConversionsScript";
 import Navigation from "../navigation";
 import Footer from "../footer";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import Layout from "../components/layouts/main";
 import FloatingLayout from "../components/layouts/floating";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
+import { googleAnalyticsPageView } from "../components/googleAnalytics";
 
 export default function GrouparooWWW(props) {
   const { Component } = props;
@@ -12,7 +13,12 @@ export default function GrouparooWWW(props) {
   useEffect(() => {
     storeInSession();
 
-    router.events.on("routeChangeComplete", scrollToTop);
+    function handleRouteChange(url) {
+      googleAnalyticsPageView(url);
+      scrollToTop();
+    }
+
+    router.events.on("routeChangeComplete", handleRouteChange);
 
     return () => {
       router.events.off("routeChangeComplete", scrollToTop);


### PR DESCRIPTION
Based on [this article](https://mariestarck.com/add-google-analytics-to-your-next-js-application-in-5-easy-steps/) sent to us from Victorious, I think this is the missing piece.  This was their exact feedback on how our ga tag was not tracking properly:

![Screen Shot 2021-07-27 at 9 32 55 AM](https://user-images.githubusercontent.com/63751206/127192551-d5fe5de5-3682-46a4-9dbd-bee65ba29f28.png)
