### PR TITLE
Open Source Data Stack Conf banner

### DIFF
--- a/components/banners/OpenSourceDataStackConfBanner.tsx
+++ b/components/banners/OpenSourceDataStackConfBanner.tsx
@@ -14,7 +14,11 @@ export function OpenSourceDataStackConfBanner({
         Grouparoo is part of the Open Source Data Stack Conference on Sept.
         28-30th.{" "}
         <strong>
-          <a href="https://www.opensourcedatastack.com" target="_blank">
+          <a
+            href="https://www.opensourcedatastack.com"
+            target="_blank"
+            rel="noreferrer"
+          >
             Register now
           </a>
         </strong>{" "}

--- a/components/banners/OpenSourceDataStackConfBanner.tsx
+++ b/components/banners/OpenSourceDataStackConfBanner.tsx
@@ -1,0 +1,24 @@
+import { Alert } from "react-bootstrap";
+import { NextRouter } from "next/router";
+
+export function OpenSourceDataStackConfBanner({
+  router,
+}: {
+  router: NextRouter;
+}) {
+  if (router.asPath !== "/") return null;
+
+  return (
+    <Alert variant="success" style={{ textAlign: "center", margin: 0 }}>
+      <small>
+        Grouparoo is part of the Open Source Data Stack Conference on Sept.
+        28-30th.{" "}
+        <strong>
+          <a href="https://www.opensourcedatastack.com" target="_blank">
+            Register now
+          </a>
+        </strong>{" "}
+      </small>
+    </Alert>
+  );
+}

--- a/components/banners/whatsNewBanner.tsx
+++ b/components/banners/whatsNewBanner.tsx
@@ -1,0 +1,23 @@
+import { Alert } from "react-bootstrap";
+import Link from "next/link";
+
+export type DisplayReleaseNote = { name: string; description: string };
+
+export function WhatsNewBanner({
+  releaseNote,
+}: {
+  releaseNote: DisplayReleaseNote;
+}) {
+  if (!releaseNote) return null;
+
+  return (
+    <Alert variant="primary" style={{ textAlign: "center", margin: 0 }}>
+      <small>
+        <strong>What's New</strong> - {releaseNote.description}{" "}
+        <Link href="/whats-new">
+          <a>Learn More</a>
+        </Link>
+      </small>
+    </Alert>
+  );
+}

--- a/components/layouts/main.tsx
+++ b/components/layouts/main.tsx
@@ -2,17 +2,14 @@ import { useState, useEffect, Children, cloneElement } from "react";
 import Head from "next/head";
 import Navigation from "../navigation";
 import Footer from "../footer";
-import { Alert } from "react-bootstrap";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import GetStarted from "../home/getStarted";
+import { OpenSourceDataStackConfBanner } from "../banners/OpenSourceDataStackConfBanner";
+import { DisplayReleaseNote, WhatsNewBanner } from "../banners/whatsNewBanner";
 
 function PageTemplate({ children }) {
   const router = useRouter();
-  const [releaseNote, setReleaseNote] = useState<{
-    name: string;
-    description: string;
-  }>(null);
+  const [releaseNote, setReleaseNote] = useState<DisplayReleaseNote>(null);
 
   useEffect(() => {
     if (router.asPath !== "/") setReleaseNote(null);
@@ -139,16 +136,8 @@ function PageTemplate({ children }) {
         <link rel="stylesheet" href="/css/prism.css"></link>
       </Head>
 
-      {releaseNote?.description ? (
-        <Alert variant="primary" style={{ textAlign: "center", margin: 0 }}>
-          <small>
-            <strong>What's New</strong> - {releaseNote.description}{" "}
-            <Link href="/whats-new">
-              <a>Learn More</a>
-            </Link>
-          </small>
-        </Alert>
-      ) : null}
+      <OpenSourceDataStackConfBanner router={router} />
+      {/* <WhatsNewBanner releaseNote={releaseNote} /> */}
 
       <div className="main">
         <Navigation />


### PR DESCRIPTION
This PR replaces the "What's New" Banner on the homepage with a new for the conference:

![Screen Shot 2021-08-06 at 1 59 31 PM](https://user-images.githubusercontent.com/303226/128570569-d79115bb-57bc-4443-ba60-6eba399c09b9.png)

That said, showing both banners didn't look that terrible?



<img width="1329" alt="Screen Shot 2021-08-06 at 1 59 24 PM" src="https://user-images.githubusercontent.com/303226/128570551-097386ca-0a2b-4940-8100-514b2b02b26c.png">
