### PR TITLE
add 301 redirect for cdp page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,11 @@ module.exports = {
         statusCode: 301,
       },
       {
+        source: "/solutions/customer-data-platform",
+        destination: "/",
+        statusCode: 301,
+      },
+      {
         source: "/blog/hubspot-destination",
         destination: "/integrations/destinations/hubspot",
         statusCode: 301,


### PR DESCRIPTION
Now that we've removed the CDP page, we should have a redirect in place in case there are any external backlinks to it. 