### PR TITLE
Add featured blog posts to header

### DIFF
--- a/__tests__/integration/blog.ts
+++ b/__tests__/integration/blog.ts
@@ -33,4 +33,11 @@ describe("integration/blog", () => {
     const header = await browser.findElement(by.tagName("h1")).getText();
     expect(header).toBe("Steps for Marketing Tests");
   });
+
+  test("featured blog posts are in the footer", async () => {
+    const testUrl = url + "/";
+    await browser.get(testUrl);
+    const footer = await browser.findElement(by.tagName("footer")).getText();
+    expect(footer).toContain("What is Data Synchronization?");
+  });
 });

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -2,6 +2,8 @@ import { Container, Row, Col } from "react-bootstrap";
 import Image from "./Image";
 import { useRouter } from "next/router";
 import Link from "next/link";
+import { FeaturedBlogPosts } from "../data/featuredBlogPosts";
+import { Fragment } from "react";
 
 function LogoAndSocialLinks({ router }) {
   const year = new Date().getFullYear();
@@ -134,6 +136,17 @@ export default function Footer() {
                   <Link href="/solutions/modern-data-stack">
                     <a>Modern Data Stack</a>
                   </Link>
+
+                  <br />
+
+                  {FeaturedBlogPosts.map((post, idx) => (
+                    <Fragment key={`featured-post-footer-${idx}`}>
+                      <Link href={post.href}>
+                        <a>{post.title}</a>
+                      </Link>
+                      <br />
+                    </Fragment>
+                  ))}
                 </div>
 
                 <hr className="d-md-none mx-auto border-light border-top-0 m-2" />

--- a/components/icons.ts
+++ b/components/icons.ts
@@ -11,6 +11,7 @@ import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faLayerGroup } from "@fortawesome/free-solid-svg-icons";
 import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { faPen } from "@fortawesome/free-solid-svg-icons";
 import { faPlug } from "@fortawesome/free-solid-svg-icons";
 import { faProjectDiagram } from "@fortawesome/free-solid-svg-icons";
 import { faPuzzlePiece } from "@fortawesome/free-solid-svg-icons";
@@ -31,6 +32,7 @@ library.add(
   faGithub,
   faLayerGroup,
   faLink,
+  faPen,
   faPlug,
   faProjectDiagram,
   faPuzzlePiece,

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -11,12 +11,17 @@ import {
 } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
+import { FeaturedBlogPosts } from "../data/featuredBlogPosts";
 
 export default function Navigation() {
   return (
     <header>
       <Container>
-        <Navbar variant="light" expand="md">
+        <Navbar
+          variant="light"
+          expand="md"
+          style={{ paddingLeft: 0, paddingRight: 0 }}
+        >
           <Navbar.Brand className="pt-3">
             <Link href="/">
               <a>
@@ -133,7 +138,7 @@ export default function Navigation() {
               </NavDropdown>
 
               <NavDropdown
-                className="pr-2 py-2 align-text-top"
+                className="pr-2 py-2 align-text-top d-md-none d-lg-inline-block"
                 title="Solutions"
                 id="basic-nav-dropdown"
               >
@@ -266,6 +271,48 @@ export default function Navigation() {
                   </a>
                 </Link>
               </div>
+
+              <NavDropdown
+                className="pr-2 py-2 align-text-top"
+                title="Blog"
+                id="basic-nav-dropdown"
+              >
+                <Container className="blogNav pt-0 mt-0">
+                  <Row>
+                    <Col xs="12" md="12" className="text-left">
+                      <Dropdown.Header>
+                        <FontAwesomeIcon
+                          color="black"
+                          icon={"pen"}
+                          size="1x"
+                          className="pr-1"
+                        />{" "}
+                        Popular Posts
+                      </Dropdown.Header>
+                      {FeaturedBlogPosts.map((post, idx) => (
+                        <Dropdown.Item key={`header-featured-post-${idx}`}>
+                          <Link href={post.href}>
+                            <a className="nav-link" role="button">
+                              {post.title}
+                            </a>
+                          </Link>
+                        </Dropdown.Item>
+                      ))}
+                      <Dropdown.Item>
+                        <Link href="/blog">
+                          <a
+                            className="nav-link"
+                            role="button"
+                            id="seeMoreLink"
+                          >
+                            Read Blog...
+                          </a>
+                        </Link>
+                      </Dropdown.Item>
+                    </Col>
+                  </Row>
+                </Container>
+              </NavDropdown>
             </Nav>
             <a
               href="https://github.com/grouparoo/grouparoo"
@@ -281,7 +328,7 @@ export default function Navigation() {
               variant="primary"
               href="/get-started"
               size="sm"
-              className="col-sm-12 col-md-3 col-lg-2 mx-0 mr-lg-2 ml-lg-2 mt-3"
+              className="col-sm-12 col-md-3 col-lg-2 mx-0  ml-lg-2 mt-3"
             >
               Get Started
             </Button>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -138,7 +138,7 @@ export default function Navigation() {
               </NavDropdown>
 
               <NavDropdown
-                className="pr-2 py-2 align-text-top d-md-none d-lg-inline-block"
+                className="pr-2 py-2 align-text-top"
                 title="Solutions"
                 id="basic-nav-dropdown"
               >
@@ -273,7 +273,7 @@ export default function Navigation() {
               </div>
 
               <NavDropdown
-                className="pr-2 py-2 align-text-top"
+                className="pr-2 py-2 align-text-top d-md-none d-lg-inline-block"
                 title="Blog"
                 id="basic-nav-dropdown"
               >

--- a/data/featuredBlogPosts.ts
+++ b/data/featuredBlogPosts.ts
@@ -1,0 +1,10 @@
+export const FeaturedBlogPosts = [
+  {
+    title: "What is Data Synchronization?",
+    href: "/blog/what-is-data-synchronization",
+  },
+  {
+    title: "What is a Data Pipeline?",
+    href: "/blog/what-is-a-data-pipeline",
+  },
+] as const;


### PR DESCRIPTION
Show off our featured blog posts.

<img width="1356" alt="Screen Shot 2021-10-28 at 1 24 01 PM" src="https://user-images.githubusercontent.com/303226/139330226-fd360123-6516-43e0-afab-f3212d9a0eaf.png">

I did not go with a mechanism to "tag" posts we want as "featured" in the frontmatter so we could have explicit control of the links, titles, and order of the featured posts.  This also means we don't need to pre-hydrate every page with a filesystem read. 

The story asked for a new blog section in the footer, but I thought it was getting really crowded.  To that end, I added the blog posts to the "Use Cases" section.  



<img width="843" alt="Screen Shot 2021-10-28 at 1 23 51 PM" src="https://user-images.githubusercontent.com/303226/139330247-c6d2412d-6f92-4ab5-8d19-e949c1a18cb7.png">
<img width="1356" alt="Screen Shot 2021-10-28 at 1 23 54 PM" src="https://user-images.githubusercontent.com/303226/139330253-492274f5-1212-4cdb-924f-278a1b3fb85d.png">
## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
