### PR TITLE
Sitemap updates

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -258,6 +258,10 @@ export default function Footer() {
                   <Link href="/legal/terms">
                     <a>Terms and Conditions</a>
                   </Link>
+                  <br />
+                  <Link href="/public-sitemap">
+                    <a>Sitemap</a>
+                  </Link>
                 </div>
               </Col>
               <Col className="d-none d-md-inline-block col-md-1" />

--- a/pages/public-sitemap.tsx
+++ b/pages/public-sitemap.tsx
@@ -43,6 +43,9 @@ export default function PublicSitemap({
 
       <div>
         <h1 className="mx-auto text-center">Sitemap</h1>
+        <SitemapIntegrationSection {...integrations} />
+        <SitemapDocsSection docs={docs} />
+
         {Object.entries(restSitemap).map(
           ([category, sitemapItems]: [string, SitemapItem[]], idx) => (
             <SitemapSection
@@ -53,8 +56,6 @@ export default function PublicSitemap({
             />
           )
         )}
-        <SitemapDocsSection docs={docs} />
-        <SitemapIntegrationSection {...integrations} />
         <SitemapBlogSection {...blog} />
       </div>
     </>
@@ -65,14 +66,14 @@ export async function getStaticProps() {
   const { entries: blogPosts } = await getBlogEntries(1, null, null, 1000);
   const sitemap: Sitemap = {
     docs: {},
-    legal: [],
-    solutions: [],
-    other: [],
     integrations: {
       sources: [],
       destinations: [],
       guides: [],
     },
+    solutions: [],
+    legal: [],
+    other: [],
     blog: {
       company: [],
       sync: [],
@@ -120,7 +121,9 @@ export async function getStaticProps() {
         sitemap.docs[category] ??= [];
         sitemap.docs[category].push({
           name: titleize(
-            rest.length > 1 ? rest.slice(-1)[0] : rest[0] ?? category
+            rest.length > 1
+              ? `${rest.slice(-2)[0]}:  ${rest.slice(-2)[1]}`
+              : rest[0] ?? category
           ),
           path,
         });

--- a/pages/public-sitemap.tsx
+++ b/pages/public-sitemap.tsx
@@ -24,6 +24,13 @@ export interface Sitemap {
   };
   blog: Record<keyof typeof badgeTypes, SitemapItem[]>;
 }
+function buildDocsTitle(category, rest) {
+  return rest.length > 1
+    ? //if there is more than one piece in "rest" to build with, combine the lowest two to make a descriptive title
+      `${rest.slice(-2)[0]}:  ${rest.slice(-2)[1]}`
+    : //otherwise give the only piece there (if it exists) or just the category name (if it doesn't)
+      rest[0] ?? category;
+}
 
 export default function PublicSitemap({
   pageProps: { sitemap },
@@ -31,6 +38,7 @@ export default function PublicSitemap({
   pageProps: { sitemap: Sitemap };
 }) {
   const { integrations, blog, docs, ...restSitemap } = sitemap;
+
   return (
     <>
       <SEO
@@ -120,11 +128,7 @@ export async function getStaticProps() {
         const [, category, ...rest] = pathParts;
         sitemap.docs[category] ??= [];
         sitemap.docs[category].push({
-          name: titleize(
-            rest.length > 1
-              ? `${rest.slice(-2)[0]}:  ${rest.slice(-2)[1]}`
-              : rest[0] ?? category
-          ),
+          name: titleize(buildDocsTitle(category, rest)),
           path,
         });
       } else {


### PR DESCRIPTION
## Change description

Fixes three issues with previous sitemap page.

(1) Adds a link to the footer
![Screen Shot 2021-11-08 at 9 13 42 AM](https://user-images.githubusercontent.com/63751206/140757298-fbd83e72-27c0-4d18-ba85-0b7ec25d2bff.png)
(2) If there is a subdirectory that isn't a category, it's still semantically important so we now include it in the anchor text rather than _only_ the filename.  (Without this, some pages like the docs for Apps and Code Config Apps would have/currently have identical anchor texts) 
![Screen Shot 2021-11-08 at 9 13 18 AM](https://user-images.githubusercontent.com/63751206/140757427-55270276-c47f-4a4e-a743-f15579ff1f1c.png)
(3) Re-ordered items in the sitemap.  Categories are now: integrations, docs, solutions, legal, other, blog.
![Screen Shot 2021-11-08 at 9 13 33 AM](https://user-images.githubusercontent.com/63751206/140757656-2b81888e-e3f2-483e-b7d7-ec803ab6e410.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
