### PR TITLE
Bootstrap theme update to fix blog tags

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,9 @@ const nextConfig = {
       process.env.GOOGLE_ADS_SUBSCRIBE_CONVERSION,
     GOOGLE_ADS_TRIAL_CONVERSION: process.env.GOOGLE_ADS_TRIAL_CONVERSION,
   },
+  sassOptions: {
+    includePaths: [require("path").join(__dirname, "scss")],
+  },
   async rewrites() {
     return [];
   },

--- a/pages/pricing.module.scss
+++ b/pages/pricing.module.scss
@@ -1,4 +1,4 @@
-@import "../scss/_variables";
+@import "_variables";
 
 .pricingList {
   font-size: 14px;

--- a/pages/pricing.module.scss
+++ b/pages/pricing.module.scss
@@ -2,3 +2,11 @@
   font-size: 14px;
   text-align: left;
 }
+
+.featureCard {
+  min-height: 501px;
+}
+
+.lightBg {
+  background-color: #dfe8fb;
+}

--- a/pages/pricing.module.scss
+++ b/pages/pricing.module.scss
@@ -1,3 +1,5 @@
+@import "../scss/_variables";
+
 .pricingList {
   font-size: 14px;
   text-align: left;
@@ -8,5 +10,5 @@
 }
 
 .lightBg {
-  background-color: #dfe8fb;
+  background-color: $grouparoo-light-violet;
 }

--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -41,9 +41,9 @@ export default function PricingPage() {
           <Row className="mx-auto row-cols-1 row-cols-md-2 row-cols-lg-3 d-flex align-items-stretch">
             <Col className="mb-4 mx-auto d-flex align-items-stretch">
               <Card
-                className="p-3 col-12 mx-auto shadow-lg h-100 text-start"
+                className={`mx-auto col-12 p-3
+shadow-lg h-100 text-start feature-card ${styles.featureCard}`}
                 bg="white"
-                style={{ minHeight: "468px" }}
               >
                 <Card.Body className="d-flex align-items-start flex-column">
                   <div className="h3">Community Edition</div>
@@ -75,10 +75,8 @@ export default function PricingPage() {
             </Col>
             <Col className="mb-4">
               <Card
-                className="mx-auto col-12 p-3
-                 shadow-lg h-100 text-start"
-                bg="info"
-                style={{ minHeight: "468px" }}
+                className={`mx-auto col-12 p-3
+                shadow-lg h-100 text-start feature-card ${styles.featureCard} ${styles.lightBg}`}
               >
                 <Card.Body className="d-flex align-items-start flex-column">
                   <div className="h3">Standard Cloud</div>
@@ -114,9 +112,8 @@ export default function PricingPage() {
 
             <Col className="mb-4 mx-auto ">
               <Card
-                className="mx-auto col-12 p-3
-                 shadow-lg h-100 text-start"
-                style={{ minHeight: "468px" }}
+                className={`mx-auto col-12 p-3
+                 shadow-lg h-100 text-start feature-card ${styles.featureCard}`}
               >
                 <Card.Body className="d-flex align-items-start flex-column">
                   <div className="h3">Enterprise Cloud</div>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,0 +1,24 @@
+// Grouparoo Colors
+
+$grouparoo-light-gray: #adb5bd;
+$grouparoo-dark-gray: #242436;
+$grouparoo-yellow: #ff7518;
+$grouparoo-light-yellow: #fff8f1;
+$grouparoo-red: #ff0039;
+$grouparoo-blue: #29abe2;
+$grouparoo-light-blue: #b3e8ff;
+$grouparoo-blue-gray: #9b9db1;
+$grouparoo-violet: #9954bb;
+$grouparoo-light-violet: #dfe8fb;
+$grouparoo-background-blue: #f6fafb;
+$grouparoo-green: #3fb618;
+
+// Bootstrap Colors, cannot be CSS variables
+$primary: $grouparoo-blue;
+$secondary: $grouparoo-dark-gray;
+$success: $grouparoo-green;
+$info: $grouparoo-violet;
+$warning: $grouparoo-yellow;
+$danger: $grouparoo-red;
+$light: $grouparoo-light-gray;
+$dark: $grouparoo-dark-gray;

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -1,30 +1,6 @@
+@import "_variables.scss";
+
 // -- Colors --
-
-// Grouparoo Colors
-
-$grouparoo-light-gray: #adb5bd;
-$grouparoo-dark-gray: #242436;
-$grouparoo-yellow: #ff7518;
-$grouparoo-light-yellow: #fff8f1;
-$grouparoo-red: #ff0039;
-$grouparoo-blue: #29abe2;
-$grouparoo-light-blue: #b3e8ff;
-$grouparoo-blue-gray: #9b9db1;
-$grouparoo-violet: #9954bb;
-$grouparoo-light-violet: #dfe8fb;
-$grouparoo-background-blue: #f6fafb;
-$grouparoo-green: #3fb618;
-
-// Bootstrap Colors
-
-$primary: $grouparoo-blue;
-$secondary: $grouparoo-dark-gray;
-$success: $grouparoo-green;
-$info: $grouparoo-violet;
-$warning: $grouparoo-yellow;
-$danger: $grouparoo-red;
-$light: $grouparoo-light-gray;
-$dark: $grouparoo-dark-gray;
 
 // -- External Components --
 @import "~bootstrap/scss/bootstrap";

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -11,7 +11,7 @@ $grouparoo-blue: #29abe2;
 $grouparoo-light-blue: #b3e8ff;
 $grouparoo-blue-gray: #9b9db1;
 $grouparoo-violet: #9954bb;
-$grouparoo-light-violet: #d3d3ff;
+$grouparoo-light-violet: #dfe8fb;
 $grouparoo-background-blue: #f6fafb;
 $grouparoo-green: #3fb618;
 
@@ -20,7 +20,7 @@ $grouparoo-green: #3fb618;
 $primary: $grouparoo-blue;
 $secondary: $grouparoo-dark-gray;
 $success: $grouparoo-green;
-$info: $grouparoo-light-violet;
+$info: $grouparoo-violet;
 $warning: $grouparoo-yellow;
 $danger: $grouparoo-red;
 $light: $grouparoo-light-gray;

--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -11,7 +11,7 @@ $grouparoo-blue: #29abe2;
 $grouparoo-light-blue: #b3e8ff;
 $grouparoo-blue-gray: #9b9db1;
 $grouparoo-violet: #9954bb;
-$grouparoo-light-violet: #dfe8fb;
+$grouparoo-light-violet: #d3d3ff;
 $grouparoo-background-blue: #f6fafb;
 $grouparoo-green: #3fb618;
 


### PR DESCRIPTION
## Change description
Sets `"info"` utility class color as `grouparoo-violet` instead of `grouparoo-light-violet`

This addresses the poor contrast on the blog tag badges:
![Screen Shot 2021-12-06 at 9 29 41 AM](https://user-images.githubusercontent.com/63751206/144863897-d6fa233a-fab5-4b8c-9d0f-f03af49ffc6b.png)


`/pricing` keeps the new, lighter, lavender color
![Screen Shot 2021-12-03 at 11 38 33 AM](https://user-images.githubusercontent.com/63751206/144639262-ec90c4aa-1695-49d5-a130-f4013061ebb4.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
