### PR TITLE
use @use instead of @import in scss modules

### DIFF
--- a/pages/pricing.module.scss
+++ b/pages/pricing.module.scss
@@ -1,4 +1,4 @@
-@import "_variables";
+@use "../scss/_variables.scss";
 
 .pricingList {
   font-size: 14px;
@@ -10,5 +10,5 @@
 }
 
 .lightBg {
-  background-color: $grouparoo-light-violet;
+  background-color: variables.$grouparoo-light-violet;
 }


### PR DESCRIPTION
## Change description

When importing scss files, we should use `@use` instead of `@import` to better optimize rendering.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
