### PR TITLE
navbar collapses on select on mobile

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -30,14 +30,12 @@ export default function Navigation() {
           <Navbar.Brand className="pt-3" onClick={() => {}}>
             <Link href="/" passHref>
               <Nav.Link>
-                <a>
-                  <Image
-                    src="/images/logo-and-wordmark-white-words.svg"
-                    alt="Grouparoo Logo"
-                    width={150}
-                    height={32}
-                  />
-                </a>
+                <Image
+                  src="/images/logo-and-wordmark-white-words.svg"
+                  alt="Grouparoo Logo"
+                  width={150}
+                  height={32}
+                />
               </Nav.Link>
             </Link>
             <span className="d-none">Grouparoo</span>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -20,6 +20,9 @@ export default function Navigation() {
   const onHomepage = useMemo(() => router.pathname === "/", [router.pathname]);
   const [expanded, setExpanded] = useState(false);
 
+  function navLinkClick() {
+    setExpanded(false)
+  }
   return (
     <header className={`pipes ${!onHomepage ? "mb-4" : ""}`}>
       <Container>
@@ -28,7 +31,7 @@ export default function Navigation() {
           expand="md"
           style={{ paddingLeft: 0, paddingRight: 0 }}
         >
-          <Navbar.Brand className="pt-3" onClick={() => setExpanded(false)}>
+          <Navbar.Brand className="pt-3" onClick={() => {setNavLink(!expanded)}}>
             <Link href="/">
               <a>
                 <Image
@@ -64,28 +67,28 @@ export default function Navigation() {
                         />{" "}
                         Sources
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations/sources/snowflake">
                           <a className="nav-link" role="button">
                             Snowflake Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations/sources/postgres">
                           <a className="nav-link" role="button">
                             Postgres Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations/sources/mysql">
                           <a className="nav-link" role="button">
                             MySQL Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() =>}>
                         <Link href="/integrations">
                           <a
                             className="nav-link"
@@ -109,28 +112,28 @@ export default function Navigation() {
                         />{" "}
                         Destinations
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations/destinations/salesforce">
                           <a className="nav-link" role="button">
                             Salesforce Data Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations/destinations/marketo">
                           <a className="nav-link" role="button">
                             Marketo Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations/destinations/zendesk">
                           <a className="nav-link" role="button">
                             Zendesk Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/integrations">
                           <a
                             className="nav-link"
@@ -163,14 +166,14 @@ export default function Navigation() {
                         />
                         Industries
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/healthcare">
                           <a className="nav-link" role="button">
                             Healthcare
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/education">
                           <a className="nav-link" role="button">
                             Education
@@ -188,21 +191,21 @@ export default function Navigation() {
                         />
                         Comparisons
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/census-alternative">
                           <a className="nav-link" role="button">
                             vs. Census
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/segment-alternative">
                           <a className="nav-link" role="button">
                             vs. Segment
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/hightouch-alternative">
                           <a className="nav-link" role="button">
                             vs. Hightouch
@@ -222,7 +225,7 @@ export default function Navigation() {
                         />
                         Departments
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/">
                           <a className="nav-link" role="button">
                             Engineering
@@ -239,14 +242,14 @@ export default function Navigation() {
                         />
                         Categories
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/reverse-etl">
                           <a className="nav-link" role="button">
                             Reverse ETL
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => setExpanded(false)}>
+                      <Dropdown.Item onClick={() => {navLinkClick()}}>
                         <Link href="/solutions/modern-data-stack">
                           <a className="nav-link" role="button">
                             Modern Data Stack
@@ -258,7 +261,7 @@ export default function Navigation() {
                 </Container>
               </NavDropdown>
 
-              <div className="nav-link" onClick={() => setExpanded(false)}>
+              <div className="nav-link" onClick={() => {navLinkClick()}}>
                 <Link href="/pricing">
                   <a className="nav-link" role="button">
                     Pricing
@@ -266,7 +269,7 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link" onClick={() => setExpanded(false)}>
+              <div className="nav-link" onClick={() => {navLinkClick()}}>
                 <Link href="/docs">
                   <a className="nav-link" role="button">
                     Docs
@@ -274,7 +277,7 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link" onClick={() => setExpanded(false)}>
+              <div className="nav-link" onClick={() => {navLinkClick()}}>
                 <Link href="/blog">
                   <a className="nav-link" role="button">
                     Blog
@@ -292,7 +295,7 @@ export default function Navigation() {
                 variant="light"
                 size="sm"
                 className={"w-100 " + styles.github}
-                onClick={() => setExpanded(false)}
+                onClick={() => {navLinkClick()}}
               >
                 <FontAwesomeIcon icon={["fab", "github"]} size="xs" /> Star
               </Button>
@@ -302,7 +305,7 @@ export default function Navigation() {
                 variant="secondary"
                 size="sm"
                 className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
-                onClick={() => setExpanded(false)}
+                onClick={() => {navLinkClick()}}
               >
                 Get Started
               </Button>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -20,9 +20,9 @@ export default function Navigation() {
   const onHomepage = useMemo(() => router.pathname === "/", [router.pathname]);
   const [expanded, setExpanded] = useState(false);
 
-  function navLinkClick() {
+  const navLinkClick = () => {
     setExpanded(false);
-  }
+  };
   return (
     <header className={`pipes ${!onHomepage ? "mb-4" : ""}`}>
       <Container>
@@ -34,7 +34,7 @@ export default function Navigation() {
           <Navbar.Brand
             className="pt-3"
             onClick={() => {
-              setNavLink(!expanded);
+              setExpanded(!expanded);
             }}
           >
             <Link href="/">

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -21,7 +21,7 @@ export default function Navigation() {
   const [expanded, setExpanded] = useState(false);
 
   function navLinkClick() {
-    setExpanded(false)
+    setExpanded(false);
   }
   return (
     <header className={`pipes ${!onHomepage ? "mb-4" : ""}`}>
@@ -31,7 +31,12 @@ export default function Navigation() {
           expand="md"
           style={{ paddingLeft: 0, paddingRight: 0 }}
         >
-          <Navbar.Brand className="pt-3" onClick={() => {setNavLink(!expanded)}}>
+          <Navbar.Brand
+            className="pt-3"
+            onClick={() => {
+              setNavLink(!expanded);
+            }}
+          >
             <Link href="/">
               <a>
                 <Image
@@ -67,28 +72,44 @@ export default function Navigation() {
                         />{" "}
                         Sources
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations/sources/snowflake">
                           <a className="nav-link" role="button">
                             Snowflake Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations/sources/postgres">
                           <a className="nav-link" role="button">
                             Postgres Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations/sources/mysql">
                           <a className="nav-link" role="button">
                             MySQL Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() =>}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations">
                           <a
                             className="nav-link"
@@ -112,28 +133,44 @@ export default function Navigation() {
                         />{" "}
                         Destinations
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations/destinations/salesforce">
                           <a className="nav-link" role="button">
                             Salesforce Data Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations/destinations/marketo">
                           <a className="nav-link" role="button">
                             Marketo Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations/destinations/zendesk">
                           <a className="nav-link" role="button">
                             Zendesk Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/integrations">
                           <a
                             className="nav-link"
@@ -166,14 +203,22 @@ export default function Navigation() {
                         />
                         Industries
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/healthcare">
                           <a className="nav-link" role="button">
                             Healthcare
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/education">
                           <a className="nav-link" role="button">
                             Education
@@ -191,21 +236,33 @@ export default function Navigation() {
                         />
                         Comparisons
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/census-alternative">
                           <a className="nav-link" role="button">
                             vs. Census
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/segment-alternative">
                           <a className="nav-link" role="button">
                             vs. Segment
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/hightouch-alternative">
                           <a className="nav-link" role="button">
                             vs. Hightouch
@@ -225,7 +282,11 @@ export default function Navigation() {
                         />
                         Departments
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/">
                           <a className="nav-link" role="button">
                             Engineering
@@ -242,14 +303,22 @@ export default function Navigation() {
                         />
                         Categories
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/reverse-etl">
                           <a className="nav-link" role="button">
                             Reverse ETL
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item onClick={() => {navLinkClick()}}>
+                      <Dropdown.Item
+                        onClick={() => {
+                          navLinkClick();
+                        }}
+                      >
                         <Link href="/solutions/modern-data-stack">
                           <a className="nav-link" role="button">
                             Modern Data Stack
@@ -261,7 +330,12 @@ export default function Navigation() {
                 </Container>
               </NavDropdown>
 
-              <div className="nav-link" onClick={() => {navLinkClick()}}>
+              <div
+                className="nav-link"
+                onClick={() => {
+                  navLinkClick();
+                }}
+              >
                 <Link href="/pricing">
                   <a className="nav-link" role="button">
                     Pricing
@@ -269,7 +343,12 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link" onClick={() => {navLinkClick()}}>
+              <div
+                className="nav-link"
+                onClick={() => {
+                  navLinkClick();
+                }}
+              >
                 <Link href="/docs">
                   <a className="nav-link" role="button">
                     Docs
@@ -277,7 +356,12 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link" onClick={() => {navLinkClick()}}>
+              <div
+                className="nav-link"
+                onClick={() => {
+                  navLinkClick();
+                }}
+              >
                 <Link href="/blog">
                   <a className="nav-link" role="button">
                     Blog
@@ -295,7 +379,9 @@ export default function Navigation() {
                 variant="light"
                 size="sm"
                 className={"w-100 " + styles.github}
-                onClick={() => {navLinkClick()}}
+                onClick={() => {
+                  navLinkClick();
+                }}
               >
                 <FontAwesomeIcon icon={["fab", "github"]} size="xs" /> Star
               </Button>
@@ -305,7 +391,9 @@ export default function Navigation() {
                 variant="secondary"
                 size="sm"
                 className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
-                onClick={() => {navLinkClick()}}
+                onClick={() => {
+                  navLinkClick();
+                }}
               >
                 Get Started
               </Button>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -13,7 +13,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import styles from "./Navigation.module.scss";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 export default function Navigation() {
   const router = useRouter();
@@ -21,13 +21,13 @@ export default function Navigation() {
 
   return (
     <header className={`pipes ${!onHomepage ? "mb-4" : ""}`}>
-      <Container>
+      <Container style={{ padding: 0 }}>
         <Navbar
           collapseOnSelect
           expand="md"
           style={{ paddingLeft: 0, paddingRight: 0 }}
         >
-          <Navbar.Brand className="pt-3" onClick={() => {}}>
+          <Navbar.Brand className="pt-3">
             <Link href="/" passHref>
               <Nav.Link>
                 <Image
@@ -60,7 +60,7 @@ export default function Navigation() {
                         />{" "}
                         Sources
                       </Dropdown.Header>
-                      <Dropdown.Item onClick={() => {}}>
+                      <Dropdown.Item>
                         <Link href="/integrations/sources/snowflake" passHref>
                           <Nav.Link>Snowflake Integration</Nav.Link>
                         </Link>
@@ -251,18 +251,22 @@ export default function Navigation() {
                 variant="light"
                 size="sm"
                 className={"w-100 " + styles.github}
+                style={{ minWidth: 70 }}
               >
                 <FontAwesomeIcon icon={["fab", "github"]} size="xs" /> Star
               </Button>
             </a>
             <Link href="/get-started" passHref>
-              <Button
-                variant="secondary"
-                size="sm"
-                className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
-              >
-                Get Started
-              </Button>
+              <Nav.Link>
+                <Button
+                  style={{ minWidth: 188 }}
+                  variant="secondary"
+                  size="sm"
+                  className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
+                >
+                  Get Started
+                </Button>
+              </Nav.Link>
             </Link>
           </Navbar.Collapse>
         </Navbar>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -301,7 +301,7 @@ export default function Navigation() {
               <Button
                 variant="secondary"
                 size="sm"
-                className="col-sm-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
+                className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
                 onClick={() => setExpanded(false)}
               >
                 Get Started

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -13,17 +13,22 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import styles from "./Navigation.module.scss";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 export default function Navigation() {
   const router = useRouter();
   const onHomepage = useMemo(() => router.pathname === "/", [router.pathname]);
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <header className={`pipes ${!onHomepage ? "mb-4" : ""}`}>
       <Container>
-        <Navbar expand="md" style={{ paddingLeft: 0, paddingRight: 0 }}>
-          <Navbar.Brand className="pt-3">
+        <Navbar
+          expanded={expanded}
+          expand="md"
+          style={{ paddingLeft: 0, paddingRight: 0 }}
+        >
+          <Navbar.Brand className="pt-3" onClick={() => setExpanded(false)}>
             <Link href="/">
               <a>
                 <Image
@@ -36,8 +41,11 @@ export default function Navigation() {
             </Link>
             <span className="d-none">Grouparoo</span>
           </Navbar.Brand>
-          <Navbar.Toggle aria-controls="basic-navbar-nav" />
-          <Navbar.Collapse id="basic-navbar-nav">
+          <Navbar.Toggle
+            aria-controls="basic-navbar-nav"
+            onClick={() => setExpanded(!expanded)}
+          />
+          <Navbar.Collapse id="basic-navbar-nav navbar-collapse">
             <Nav className="ms-auto mt-3">
               <NavDropdown
                 className="pe-2 py-2 align-text-top"
@@ -56,28 +64,28 @@ export default function Navigation() {
                         />{" "}
                         Sources
                       </Dropdown.Header>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations/sources/snowflake">
                           <a className="nav-link" role="button">
                             Snowflake Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations/sources/postgres">
                           <a className="nav-link" role="button">
                             Postgres Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations/sources/mysql">
                           <a className="nav-link" role="button">
                             MySQL Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations">
                           <a
                             className="nav-link"
@@ -101,28 +109,28 @@ export default function Navigation() {
                         />{" "}
                         Destinations
                       </Dropdown.Header>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations/destinations/salesforce">
                           <a className="nav-link" role="button">
                             Salesforce Data Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations/destinations/marketo">
                           <a className="nav-link" role="button">
                             Marketo Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations/destinations/zendesk">
                           <a className="nav-link" role="button">
                             Zendesk Integration
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/integrations">
                           <a
                             className="nav-link"
@@ -155,14 +163,14 @@ export default function Navigation() {
                         />
                         Industries
                       </Dropdown.Header>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/healthcare">
                           <a className="nav-link" role="button">
                             Healthcare
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/education">
                           <a className="nav-link" role="button">
                             Education
@@ -180,21 +188,21 @@ export default function Navigation() {
                         />
                         Comparisons
                       </Dropdown.Header>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/census-alternative">
                           <a className="nav-link" role="button">
                             vs. Census
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/segment-alternative">
                           <a className="nav-link" role="button">
                             vs. Segment
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/hightouch-alternative">
                           <a className="nav-link" role="button">
                             vs. Hightouch
@@ -214,7 +222,7 @@ export default function Navigation() {
                         />
                         Departments
                       </Dropdown.Header>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/">
                           <a className="nav-link" role="button">
                             Engineering
@@ -231,14 +239,14 @@ export default function Navigation() {
                         />
                         Categories
                       </Dropdown.Header>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/reverse-etl">
                           <a className="nav-link" role="button">
                             Reverse ETL
                           </a>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item>
+                      <Dropdown.Item onClick={() => setExpanded(false)}>
                         <Link href="/solutions/modern-data-stack">
                           <a className="nav-link" role="button">
                             Modern Data Stack
@@ -250,7 +258,7 @@ export default function Navigation() {
                 </Container>
               </NavDropdown>
 
-              <div className="nav-link">
+              <div className="nav-link" onClick={() => setExpanded(false)}>
                 <Link href="/pricing">
                   <a className="nav-link" role="button">
                     Pricing
@@ -258,7 +266,7 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link">
+              <div className="nav-link" onClick={() => setExpanded(false)}>
                 <Link href="/docs">
                   <a className="nav-link" role="button">
                     Docs
@@ -266,7 +274,7 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link">
+              <div className="nav-link" onClick={() => setExpanded(false)}>
                 <Link href="/blog">
                   <a className="nav-link" role="button">
                     Blog
@@ -284,6 +292,7 @@ export default function Navigation() {
                 variant="light"
                 size="sm"
                 className={"w-100 " + styles.github}
+                onClick={() => setExpanded(false)}
               >
                 <FontAwesomeIcon icon={["fab", "github"]} size="xs" /> Star
               </Button>
@@ -293,6 +302,7 @@ export default function Navigation() {
                 variant="secondary"
                 size="sm"
                 className="col-sm-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
+                onClick={() => setExpanded(false)}
               >
                 Get Started
               </Button>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -18,41 +18,31 @@ import { useMemo, useState } from "react";
 export default function Navigation() {
   const router = useRouter();
   const onHomepage = useMemo(() => router.pathname === "/", [router.pathname]);
-  const [expanded, setExpanded] = useState(false);
 
-  const navLinkClick = () => {
-    setExpanded(false);
-  };
   return (
     <header className={`pipes ${!onHomepage ? "mb-4" : ""}`}>
       <Container>
         <Navbar
-          expanded={expanded}
+          collapseOnSelect
           expand="md"
           style={{ paddingLeft: 0, paddingRight: 0 }}
         >
-          <Navbar.Brand
-            className="pt-3"
-            onClick={() => {
-              setExpanded(!expanded);
-            }}
-          >
-            <Link href="/">
-              <a>
-                <Image
-                  src="/images/logo-and-wordmark-white-words.svg"
-                  alt="Grouparoo Logo"
-                  width={150}
-                  height={32}
-                />
-              </a>
+          <Navbar.Brand className="pt-3" onClick={() => {}}>
+            <Link href="/" passHref>
+              <Nav.Link>
+                <a>
+                  <Image
+                    src="/images/logo-and-wordmark-white-words.svg"
+                    alt="Grouparoo Logo"
+                    width={150}
+                    height={32}
+                  />
+                </a>
+              </Nav.Link>
             </Link>
             <span className="d-none">Grouparoo</span>
           </Navbar.Brand>
-          <Navbar.Toggle
-            aria-controls="basic-navbar-nav"
-            onClick={() => setExpanded(!expanded)}
-          />
+          <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Navbar.Collapse id="basic-navbar-nav navbar-collapse">
             <Nav className="ms-auto mt-3">
               <NavDropdown
@@ -72,52 +62,24 @@ export default function Navigation() {
                         />{" "}
                         Sources
                       </Dropdown.Header>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations/sources/snowflake">
-                          <a className="nav-link" role="button">
-                            Snowflake Integration
-                          </a>
+                      <Dropdown.Item onClick={() => {}}>
+                        <Link href="/integrations/sources/snowflake" passHref>
+                          <Nav.Link>Snowflake Integration</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations/sources/postgres">
-                          <a className="nav-link" role="button">
-                            Postgres Integration
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/integrations/sources/postgres" passHref>
+                          <Nav.Link>Postgres Integration</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations/sources/mysql">
-                          <a className="nav-link" role="button">
-                            MySQL Integration
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/integrations/sources/mysql" passHref>
+                          <Nav.Link>MySQL Integration</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations">
-                          <a
-                            className="nav-link"
-                            role="button"
-                            id="seeMoreLink"
-                          >
-                            See More...
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/integrations" passHref>
+                          <Nav.Link id="seeMoreLink">See More...</Nav.Link>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Divider className="d-lg-none" />
@@ -133,52 +95,33 @@ export default function Navigation() {
                         />{" "}
                         Destinations
                       </Dropdown.Header>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations/destinations/salesforce">
-                          <a className="nav-link" role="button">
-                            Salesforce Data Integration
-                          </a>
+                      <Dropdown.Item>
+                        <Link
+                          href="/integrations/destinations/salesforce"
+                          passHref
+                        >
+                          <Nav.Link>Salesforce Data Integration</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations/destinations/marketo">
-                          <a className="nav-link" role="button">
-                            Marketo Integration
-                          </a>
+                      <Dropdown.Item>
+                        <Link
+                          href="/integrations/destinations/marketo"
+                          passHref
+                        >
+                          <Nav.Link>Marketo Integration</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations/destinations/zendesk">
-                          <a className="nav-link" role="button">
-                            Zendesk Integration
-                          </a>
+                      <Dropdown.Item>
+                        <Link
+                          href="/integrations/destinations/zendesk"
+                          passHref
+                        >
+                          <Nav.Link>Zendesk Integration</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/integrations">
-                          <a
-                            className="nav-link"
-                            role="button"
-                            id="seeMoreLink"
-                          >
-                            See More...
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/integrations" passHref>
+                          <Nav.Link>See More...</Nav.Link>
                         </Link>
                       </Dropdown.Item>
                     </Col>
@@ -203,26 +146,14 @@ export default function Navigation() {
                         />
                         Industries
                       </Dropdown.Header>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/healthcare">
-                          <a className="nav-link" role="button">
-                            Healthcare
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/healthcare" passHref>
+                          <Nav.Link>Healthcare</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/education">
-                          <a className="nav-link" role="button">
-                            Education
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/education" passHref>
+                          <Nav.Link> Education</Nav.Link>
                         </Link>
                       </Dropdown.Item>
 
@@ -236,37 +167,19 @@ export default function Navigation() {
                         />
                         Comparisons
                       </Dropdown.Header>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/census-alternative">
-                          <a className="nav-link" role="button">
-                            vs. Census
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/census-alternative" passHref>
+                          <Nav.Link>vs. Census</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/segment-alternative">
-                          <a className="nav-link" role="button">
-                            vs. Segment
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/segment-alternative" passHref>
+                          <Nav.Link> vs. Segment</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/hightouch-alternative">
-                          <a className="nav-link" role="button">
-                            vs. Hightouch
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/hightouch-alternative" passHref>
+                          <Nav.Link> vs. Hightouch</Nav.Link>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Divider className="d-lg-none" />
@@ -282,15 +195,9 @@ export default function Navigation() {
                         />
                         Departments
                       </Dropdown.Header>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/">
-                          <a className="nav-link" role="button">
-                            Engineering
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/" passHref>
+                          <Nav.Link> Engineering</Nav.Link>
                         </Link>
                       </Dropdown.Item>
                       <Dropdown.Divider />
@@ -303,26 +210,14 @@ export default function Navigation() {
                         />
                         Categories
                       </Dropdown.Header>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/reverse-etl">
-                          <a className="nav-link" role="button">
-                            Reverse ETL
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/reverse-etl" passHref>
+                          <Nav.Link> Reverse ETL</Nav.Link>
                         </Link>
                       </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => {
-                          navLinkClick();
-                        }}
-                      >
-                        <Link href="/solutions/modern-data-stack">
-                          <a className="nav-link" role="button">
-                            Modern Data Stack
-                          </a>
+                      <Dropdown.Item>
+                        <Link href="/solutions/modern-data-stack" passHref>
+                          <Nav.Link> Modern Data Stack</Nav.Link>
                         </Link>
                       </Dropdown.Item>
                     </Col>
@@ -330,42 +225,21 @@ export default function Navigation() {
                 </Container>
               </NavDropdown>
 
-              <div
-                className="nav-link"
-                onClick={() => {
-                  navLinkClick();
-                }}
-              >
-                <Link href="/pricing">
-                  <a className="nav-link" role="button">
-                    Pricing
-                  </a>
+              <div className="nav-link">
+                <Link href="/pricing" passHref>
+                  <Nav.Link> Pricing</Nav.Link>
                 </Link>
               </div>
 
-              <div
-                className="nav-link"
-                onClick={() => {
-                  navLinkClick();
-                }}
-              >
-                <Link href="/docs">
-                  <a className="nav-link" role="button">
-                    Docs
-                  </a>
+              <div className="nav-link">
+                <Link href="/docs" passHref>
+                  <Nav.Link> Docs</Nav.Link>
                 </Link>
               </div>
 
-              <div
-                className="nav-link"
-                onClick={() => {
-                  navLinkClick();
-                }}
-              >
-                <Link href="/blog">
-                  <a className="nav-link" role="button">
-                    Blog
-                  </a>
+              <div className="nav-link">
+                <Link href="/blog" passHref>
+                  <Nav.Link> Blog</Nav.Link>
                 </Link>
               </div>
             </Nav>
@@ -379,9 +253,6 @@ export default function Navigation() {
                 variant="light"
                 size="sm"
                 className={"w-100 " + styles.github}
-                onClick={() => {
-                  navLinkClick();
-                }}
               >
                 <FontAwesomeIcon icon={["fab", "github"]} size="xs" /> Star
               </Button>
@@ -391,9 +262,6 @@ export default function Navigation() {
                 variant="secondary"
                 size="sm"
                 className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"
-                onClick={() => {
-                  navLinkClick();
-                }}
               >
                 Get Started
               </Button>


### PR DESCRIPTION
## Change description

Because we use nextjs `Link` instead of the bootstrap `NavLink` component, we don't have all the built-in functionality like auto-collapse on item select.

Now each item has an onClick handler to set expanded=false.

![menu-gif](https://user-images.githubusercontent.com/63751206/147122266-2d1bc3bd-4768-4f8b-8cb8-965484385cd7.gif)

Also, "Get Started" button width matches github button width on mobile now.


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
