### PR TITLE
Fix firefox `scrollToTop` bug, Disable smooth scroll

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,22 +32,12 @@ export default function GrouparooWWW(props) {
 
   useEffect(() => {
     storeInSession();
-
-    function handleRouteChange(url: string) {
-      googleAnalyticsPageView(url);
-      scrollToTop();
-    }
-
-    router.events.on("routeChangeComplete", handleRouteChange);
+    router.events.on("routeChangeComplete", googleAnalyticsPageView);
 
     return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
+      router.events.off("routeChangeComplete", googleAnalyticsPageView);
     };
   }, [router.asPath, router.events, router.isReady, storeInSession]);
-
-  function scrollToTop() {
-    globalThis.scrollTo(0, 0);
-  }
 
   function storeQueryToSession(storage: Storage, key: string, value: string) {
     if (!value) return;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -36,6 +36,7 @@ $navbar-light-color: $grouparoo-nav-font-color;
 $navbar-light-hover-color: $grouparoo-nav-font-color;
 
 // Bootstrap Overrides
+$enable-smooth-scroll: false; // fixes a bug in which sometimes Firefox browsers would not scroll to top
 $card-border-radius: 8px;
 
 // -- Fonts --


### PR DESCRIPTION
This PR disable's bootstrap's default behavior of enabling "smooth" scrolling behavior to fix a [bug](https://www.pivotaltracker.com/story/show/180790511) in which sometimes Firefox Browsers would not scroll to the top of the page when a link was clicked.  This PR is also a stylistic choice to disable smooth scrolling.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
