### PR TITLE
Capitalization consistency on `/docs/config/destinations`

### DIFF
--- a/pages/docs/config/destinations.mdx
+++ b/pages/docs/config/destinations.mdx
@@ -7,14 +7,14 @@ pullQuote: "Learn how to configure destinations using Grouparoo's UI Config."
 <Alert variant="warning">
   <p className="mb-0">
     You usually want to have an <a href="/docs/config/apps">App</a>,{" "}
-    <a href="/docs/config/sources">source</a>,{" "}
-    <a href="/docs/config/properties">a few properties</a>, and{" "}
+    <a href="/docs/config/sources">Source</a>,{" "}
+    <a href="/docs/config/properties">a few Properties</a>, and{" "}
     <a href="/docs/config/groups">at least one Group</a> before creating a
     Destination.
   </p>
 </Alert>
 
-Once you have all other items configuration, you're ready to setup your destinations. Destinations are the last piece of the puzzle, the place(s) you want to send your customer data so you can take action on your workflows. [See this doc](/docs/getting-started/product-concepts) to learn more about the core concepts in Grouparoo.
+Once you have all other items configuration, you're ready to setup your Destinations. Destinations are the last piece of the puzzle, the place(s) you want to send your customer data so you can take action on your workflows. [See this doc](/docs/getting-started/product-concepts) to learn more about the core concepts in Grouparoo.
 
 Here's how to send Records, Groups, and Record properties to destinations:
 
@@ -30,7 +30,7 @@ Click on _Destinations_ in the left-nav and then click _Add New Destination_.
   height={646}
 />
 
-Choose the kind of Destination you'd like to create from the list of available apps. The choices shown will be based on which apps you've already connected. If you don't see the App you want to use, you can [add a new App](/docs/config/apps).
+Choose the kind of Destination you'd like to create from the list of available apps. The choices shown will be based on which Apps you've already connected. If you don't see the App you want to use, you can [add a new App](/docs/config/apps).
 
 <ImageInBrowserFrame
   centered
@@ -52,7 +52,7 @@ Once you've selected the type of App, the specific questions and settings will v
   height={791}
 />
 
-In addition to any plugin-specific Destination options, you will also be asked to choose a SyncMode. Grouparoo supports 3 types of SyncModes which determine how we deal with creating and deleting records for the Destination.
+In addition to any Plugin-specific Destination options, you will also be asked to choose a SyncMode. Grouparoo supports 3 types of SyncModes which determine how we deal with creating and deleting records for the Destination.
 
 - **Sync** (`sync`): Add, update, and remove Records as needed.
 - **Additive** (`additive`): Add and update Records as needed, but do not remove anybody.


### PR DESCRIPTION
## Change description

Small fix.  Noticed some capitalization inconsistencies on `/config/destinations` when reviewing another PR.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
