### PR TITLE
set default image on SEO component

### DIFF
--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -32,7 +32,7 @@ const getTwitterCardType = ({ image, twitterCard }) => {
 const SEO = ({
   canonical,
   description,
-  image,
+  image = "/home/twitter-og-image.png",
   title,
   twitterAuthor,
   twitterCard,


### PR DESCRIPTION
## Change description

Across the pages using our `SEO` component, default to our logo card if one hasn't been set.

**Before**:
![image](https://user-images.githubusercontent.com/4368928/149998138-d2a57b0b-1a9f-4754-8e5c-7eaeef56be04.png)

**After**:
![image](https://user-images.githubusercontent.com/4368928/149998188-430b224b-8e49-4a71-a8fb-c38d995de6e9.png)

## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
