### PR TITLE
Fix visiblity of svg icons in nav dropdowns

### DIFF
--- a/scss/grouparoo.scss
+++ b/scss/grouparoo.scss
@@ -257,7 +257,8 @@ a,
   .dropdown-menu {
     background-color: #fff;
     .nav-link,
-    .dropdown-header {
+    .dropdown-header,
+    .dropdown-header * {
       color: $grouparoo-font-color !important;
     }
   }


### PR DESCRIPTION
## Change description
Fixes the color of the icons in the menu dropdowns.

Before:
![image](https://user-images.githubusercontent.com/168664/151046978-d4a755eb-8d1a-4329-bdd6-aa41897c150e.png)


After:
![image](https://user-images.githubusercontent.com/168664/151046939-dc2d2b38-4aa4-474c-8963-5422ff41f857.png)


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
