### PR TITLE
Replace `grouparoo generate` with `grouparoo config` in CLI docs

### DIFF
--- a/components/docs/CLICommands.tsx
+++ b/components/docs/CLICommands.tsx
@@ -1,7 +1,11 @@
 import { Fragment } from "react";
 import CLICommandData from "../../data/cli-commands.json";
 
-export default function CLICommand({ name }) {
+interface Props {
+  name: string;
+}
+
+export default function CLICommand({ name }: Props) {
   const data = CLICommandData.find((c) => {
     const chunk = c.name.split(" ")[0];
     return chunk === name;

--- a/components/docs/GeneratedConfigFile.tsx
+++ b/components/docs/GeneratedConfigFile.tsx
@@ -1,4 +1,5 @@
-import { Button } from "react-bootstrap";
+// import { Button } from "react-bootstrap";
+// TODO: Re-enable learn more about config files to new config files section
 
 export default function GeneratedConfigFile({ configDir, docPath }) {
   return (
@@ -12,9 +13,9 @@ export default function GeneratedConfigFile({ configDir, docPath }) {
         can further edit this file locally or through the UI Config.
       </p>
 
-      <Button href={docPath} variant="outline-primary">
+      {/* <Button href={docPath} variant="outline-primary">
         Learn more about config files
-      </Button>
+      </Button> */}
     </>
   );
 }

--- a/data/cli-commands.json
+++ b/data/cli-commands.json
@@ -27,11 +27,6 @@
     "name": "config [options]",
     "description": "Interactively configure Grouparoo",
     "inputs": {
-      "help": {
-        "default": false,
-        "description": "display help for command",
-        "letter": "h"
-      },
       "timestamps": {
         "default": false,
         "description": "Should timestamps be prepended to each log line?",

--- a/data/cli-commands.json
+++ b/data/cli-commands.json
@@ -24,6 +24,23 @@
     "inputs": {}
   },
   {
+    "name": "config [options]",
+    "description": "Interactively configure Grouparoo",
+    "inputs": {
+      "help": {
+        "default": false,
+        "description": "display help for command",
+        "letter": "h"
+      },
+      "timestamps": {
+        "default": false,
+        "description": "Should timestamps be prepended to each log line?",
+        "letter": "t",
+        "flag": true
+      }
+    }
+  },
+  {
     "name": "apply",
     "description": "Apply changes from code config",
     "example": "",
@@ -51,60 +68,6 @@
         "description": "Should timestamps be prepended to each log line?",
         "letter": "t",
         "flag": true
-      }
-    }
-  },
-  {
-    "name": "generate [template] [id]",
-    "description": "Generate new code config files from templates. ",
-    "example": "App generation:\n    grouparoo generate postgres:app data_warehouse\n\n  Simple Source Generation (needs parent App):\n    grouparoo generate postgres:table:source users_table \\\n      --parent data_warehouse\n\n  Batch Source Generation (needs parent app to be applied first):\n    grouparoo generate postgres:table:source users_table \\\n      --parent data_warehouse \\\n      --from users \\\n      --with id,first_name,email,last_name \\\n      --mapping 'id=user_id' \\\n      --high-water-mark updated_at\n    ",
-    "inputs": {
-      "list": {
-        "required": false,
-        "default": false,
-        "letter": "l",
-        "flag": true,
-        "description": "Display the available config templates to use with config-generate.  You can Filter the list of templates by providing a string to match against, ie: `grouparoo generate app --list` to see templates which match \"app\""
-      },
-      "describe": {
-        "required": false,
-        "default": false,
-        "letter": "d",
-        "flag": true,
-        "description": "Display the options for the template in detail"
-      },
-      "parent": {
-        "required": false,
-        "letter": "p",
-        "description": "The id of the object that is the direct parent of this new object, e.g. the appId if you are creating a new Source."
-      },
-      "from": {
-        "required": false,
-        "letter": "f",
-        "description": "For batch Generators, where should we read the objects from?"
-      },
-      "with": {
-        "required": false,
-        "letter": "w",
-        "description": "For batch Generators, what additional objects should we create? Use commas to separate names (--with \"id,first_name,last_name\") or \"*\" for all (`--with \"*\"`). Default is ``",
-        "default": ""
-      },
-      "mapping": {
-        "required": false,
-        "letter": "m",
-        "description": "For batch Generators, how should we map this object? The remote key precedes the Grouparoo Property name. Use = to set the pair (--mapping \"id=user_id\")."
-      },
-      "high-water-mark": {
-        "required": false,
-        "letter": "H",
-        "description": "For batch Generators, what should we use for the high-water-mark?"
-      },
-      "overwrite": {
-        "required": true,
-        "default": false,
-        "letter": "o",
-        "flag": true,
-        "description": "Overwrite existing files?"
       }
     }
   },

--- a/data/docs-nav.ts
+++ b/data/docs-nav.ts
@@ -54,32 +54,6 @@ const DocsNav: NavItem[] = [
       { title: "Groups", path: "/docs/config/groups" },
       { title: "Destinations", path: "/docs/config/destinations" },
       { title: "Sample Records", path: "/docs/config/records" },
-      {
-        title: "Code Config",
-        path: "/docs/config/code-config",
-        children: [
-          {
-            title: "Apps",
-            path: "/docs/config/code-config/apps",
-          },
-          {
-            title: "Sources",
-            path: "/docs/config/code-config/sources",
-          },
-          {
-            title: "Properties",
-            path: "/docs/config/code-config/properties",
-          },
-          {
-            title: "Groups",
-            path: "/docs/config/code-config/groups",
-          },
-          {
-            title: "Destinations",
-            path: "/docs/config/code-config/destinations",
-          },
-        ],
-      },
     ],
   },
 

--- a/data/docs-nav.ts
+++ b/data/docs-nav.ts
@@ -54,6 +54,33 @@ const DocsNav: NavItem[] = [
       { title: "Groups", path: "/docs/config/groups" },
       { title: "Destinations", path: "/docs/config/destinations" },
       { title: "Sample Records", path: "/docs/config/records" },
+      // TODO: Remove this commented out code once Code Config docs are removed.
+      // {
+      //   title: "Code Config",
+      //   path: "/docs/config/code-config",
+      //   children: [
+      //     {
+      //       title: "Apps",
+      //       path: "/docs/config/code-config/apps",
+      //     },
+      //     {
+      //       title: "Sources",
+      //       path: "/docs/config/code-config/sources",
+      //     },
+      //     {
+      //       title: "Properties",
+      //       path: "/docs/config/code-config/properties",
+      //     },
+      //     {
+      //       title: "Groups",
+      //       path: "/docs/config/code-config/groups",
+      //     },
+      //     {
+      //       title: "Destinations",
+      //       path: "/docs/config/code-config/destinations",
+      //     },
+      //   ],
+      // },
     ],
   },
 

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Command-Line Interface (CLI)"
-date: "2021-02-08"
+date: "2022-02-02"
 pullQuote: "Detailed information about the Grouparoo CLI commands."
 ---
 
@@ -18,7 +18,7 @@ You can obtain the grouparoo CLI via NPM with `npm install -g grouparoo`.
 
 ### Configuration
 
-- [`grouparoo generate [options] [template] [id]`](/docs/cli/config#generate) - Generate a config file for an new object (App, Source, Property, Destination, etc) from a template.
+- [`grouparoo config`](/docs/cli/config#config) - Starts the UI application to manage your config files
 - [`grouparoo validate (--local)`](/docs/cli/config#validate) - Test and validate your code config. Doesn't write changes to the database. Optionally disable checking with remote Apps.
 - [`grouparoo apply (--local)`](/docs/cli/config#apply) - Apply config changes to the database. This also happens automatically with `grouparoo start` and `grouparoo run` as well. Optionally disable checking with remote Apps.
 
@@ -50,12 +50,8 @@ npm install -g grouparoo
 # initialize the project (in a new directory)
 grouparoo init .
 
-# create an App, Source, and Properties
-grouparoo generate postgres:app data_warehouse
-grouparoo generate postgres:table:source users_table --parent data_warehouse
-grouparoo generate postgres:table:property email --parent users_table
-grouparoo generate postgres:table:property first_name --parent users_table
-grouparoo generate postgres:table:property last_name --parent users_table
+# configure your project
+grouparoo config
 
 # check out config files
 grouparoo validate

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -50,7 +50,7 @@ npm install -g grouparoo
 # initialize the project (in a new directory)
 grouparoo init .
 
-# configure your project
+# configure the project
 grouparoo config
 
 # check out config files

--- a/pages/docs/cli/config.mdx
+++ b/pages/docs/cli/config.mdx
@@ -1,78 +1,10 @@
 ---
 title: "CLI: Configuration"
-date: "2021-02-08"
+date: "2022-02-02"
 pullQuote: "CLI commands for configuring your Grouparoo application."
 ---
 
-<CLICommand name="generate" />
-
-The generate command will create a template configuration file for you that you will then need to fill out.
-
-#### `grouparoo generate --list`
-
-There are many templates which you can use to generate from, depending on the plugins you have installed. You can use the `--list` flag to see available templates and filter the results. For example:
-
-```
-grouparoo generate --list postgres
-
-Available Templates: matching "postgres"
-
-  postgres:app (id) - Config for a Grouparoo postgres App
-  postgres:destination (id, parent) - Config for a postgres Destination
-  postgres:query:property (id, parent) - Config for a postgres Query Property
-  postgres:query:source (id, parent) - Config for a postgres query Source. Work with multiple tables and build custom queries for its properties.
-  postgres:table:property (id, parent) - Config for a postgres Table Property
-  postgres:table:source (id, parent, from, mapping, with, high-water-mark) - Config for a postgres table Source. Construct Sources and Properties without writing SQL.
-```
-
-You are required to provide and `id` to the generate command. This `id` will be used in the file, to set the filename, and may be used by you later. For example if you generated an App called `data_warehouse`, in your sources you would set `appId: "data_warehouse"` to indicate those sources rely on the `data_warehouse` App.
-
-You can learn more about the [configuration files here](/docs/config/code-config).
-
-#### `grouparoo generate --describe`
-
-You can use the `--describe flag` to see more information about the possible options you can use to generate a new object.
-
-```
-grouparoo generate postgres:table:source --describe
-
-🦘 Grouparoo: generate postgres:table:source
-
-Config for a postgres table Source. Construct Sources and Properties without writing SQL.
-
-Required Inputs:
-  * id (required) - The id of this new Source
-  * parent (required) - The id of the postgres App to use for this Source, e.g: `--parent data_warehouse`
-
-Optional Inputs:
-  * from - The table to use for this source, e.g: `--from users`
-  * high-water-mark - The name of the column to uses for this Source's Schedule, e.g: `--high-water-mark updated_at`.
-  * mapping - The Mapping between a column in this table and a Grouparoo Property, e.g: `--mapping "id=user_id"`
-  * with - The names of the columns to create properties from, e.g: `--with users,id,first_name,last_name`. Defaults to '*'
-```
-
-#### Batch Generation
-
-Certain plugins may provide additional generation options to help you generate many objects at once. For example, if you have a valid [`App`](/docs/config/code-config/apps) already configured and applied, Grouparoo can inspect that App and generate a Source and Properties automatically for you. Batch generation is signified by using the `--from` flag, and potentially the `--with`, `--mapping` and `--high-water-mark` flags as well.
-
-For example, the `@grouparoo/postgres`, `@grouparoo/mysql`,`@grouparoo/redshift`, `@grouparoo/bigquery` and `@grouparoo/snowflake` sources all support batch source generation:
-
-```bash
-# first, make an App
-grouparoo generate postgres:app data_warehouse
-# (fill out the App config)
-grouparoo apply
-
-# Then generate the Source, Schedule, and Properties all at once
-grouparoo generate postgres:table:source users_table \
-  --parent data_warehouse \
-  --from users \ # The table to use
-  --with id,first_name,email,last_name \  # The columns to make into properties (default *)
-  --mapping 'id=user_id' \ # How the Mapping should shake out
-  --high-water-mark updated_at
-```
-
-The above commands would create a Source, Schedule, and 4 Properties.
+<CLICommand name="config" />
 
 <CLICommand name="validate" />
 

--- a/pages/docs/config.mdx
+++ b/pages/docs/config.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-date: "2022-01-31"
+date: "2022-02-02"
 pullQuote: "Learn how to use UI Config to configure your Grouparoo application."
 ---
 
@@ -50,7 +50,3 @@ There are a handful of guides to help you through the configuration process with
 - [Groups](/docs/config/groups)
 - [Destinations](/docs/config/destinations)
 - [Sample Records](/docs/config/records)
-
-## Using the CLI
-
-You can also use [Grouparoo's CLI](/docs/cli) to generate config files. See [Code Config](/docs/config/code-config) for more information on generating config files on the command line.

--- a/pages/docs/getting-started/product-concepts.mdx
+++ b/pages/docs/getting-started/product-concepts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Product Concepts"
-date: "2022-01-25"
+date: "2022-02-02"
 pullQuote: "Learn about the terminology that Grouparoo uses."
 pageNavSelector: "h2"
 ---
@@ -78,12 +78,6 @@ See [our Integrations page](/integrations) for an up-to-date list of our support
 ## Filter
 
 Filters are a series of rules used to filter data into some desired subset.
-
-## Generator
-
-A Generator is an engine that builds config files for you, based on some input. Generators are accessed via [the CLI's `generate` command](/docs/cli/config#generate). Generators use templates from [Plugins](#plugins) to build the appropriate configuration files for you.
-
-You can learn more about Generators by reading through [the Code Config docs](/docs/config/code-config).
 
 ## Group
 

--- a/pages/docs/running/orchestration.mdx
+++ b/pages/docs/running/orchestration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ELT & ETL Orchestration"
-date: "2021-11-11"
+date: "2022-02-02"
 pullQuote: "It's easy to integrate Grouparoo into your existing ELT/ELT process"
 ---
 
@@ -111,7 +111,7 @@ Note that in order to use this method, your API Key will need read access to the
 
 ## Triggering Schedules via a Query
 
-Grouparoo can be run by querying a table within your App using an App Refresh Query when configuring your App. For more information on implementing an App Refresh Query, check out our [App Configuration docs](/docs/config/apps), or you're using code config, check out [App Code Config docs](/docs/config/code-config/apps).
+Grouparoo can be run by querying a table within your App using an App Refresh Query when configuring your App. For more information on implementing an App Refresh Query, check out our [App Configuration docs](/docs/config/apps).
 
 At a high level, using a query to orchestrate your runs allows you to do things like sync data from multiple sources when a particular source, or even a meta or logs table, has new data.
 
@@ -119,7 +119,7 @@ At a high level, using a query to orchestrate your runs allows you to do things 
 
 Grouparoo can always be run via the command line with [`grouparoo run`](/docs/cli/run#run). It is important to note that this method runs once and then terminates when the job is completed. The `grouparoo run` command is a manual option that allows you to check for updates only once, each time you explicitly run it.
 
-Some customers may want to run Grouparoo via the CLI directly from their orchestrator as the final part of their ETL/ELT pipeline. Alternatively, it could simply run every night via `cron`. For these use cases, we recommend configuring Grouparoo via [code config](/docs/config/code-config) and using the `grouparoo run` command. This will run all Schedules immediately when `grouparoo run` is started.
+Some customers may want to run Grouparoo via the CLI directly from their orchestrator as the final part of their ETL/ELT pipeline. Alternatively, it could simply run every night via `cron`. For these use cases, we recommend configuring Grouparoo via the [config UI](/docs/config) and using the `grouparoo run` command. This will run all Schedules immediately when `grouparoo run` is started.
 
 ```bash
 $ grouparoo run

--- a/pages/docs/running/testing.mdx
+++ b/pages/docs/running/testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Testing Grouparoo"
-date: "2021-02-02"
+date: "2022-02-02"
 pullQuote: "Grouparoo provides the tools you need to write expectation and snapshot tests against your data."
 ---
 
@@ -60,7 +60,7 @@ In Jest, you can do expectation testing (`a` should equal `1`) or snapshot testi
 
 In this example:
 
-- Your application is already fully configured with Apps, Sources, etc via [Code Config](/docs/config/code-config)
+- Your application is already fully configured with Apps, Sources, etc via [Config UI](/docs/config).
 - You have specified a test postgres or SQLite database to use via `DATABASE_URL` or a test-specific `GROUPAROO_ENV_CONFIG_FILE`
 - `"person@example"` is a user in your source database that we are testing.
 


### PR DESCRIPTION
## Change description

This change removes the references to `grouparoo generate` from CLI docs and replaces them with `grouparoo config` instead.

## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
