### PR TITLE
Prevent Vercel from adding deployment comments to PRs and the main branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,8 @@
 {
+  "github": {
+    "silent": true
+  },
+  
   "redirects": [
     {
       "source": "/_next",


### PR DESCRIPTION
I find the comments that Vervel makes annoying.  This PR turns them off. 
Don't worry though, we still get the "View Deployment" badges (see below)

<img width="885" alt="Screen Shot 2022-02-10 at 8 10 39 AM" src="https://user-images.githubusercontent.com/303226/153448423-adc2fb45-9381-47ee-a861-07999130eb07.png">


## Checklists

### Development

- [x] Application changes have been tested appropriately

### Impact

- [x] Code follows company security practices and guidelines
- [x] Security impact of change has been considered
- [x] Performance impact of change has been considered
- [x] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [x] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
