### PR TITLE
fix: don't overflow nav on tablets

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -235,7 +235,7 @@ export default function Navigation() {
                 </Link>
               </div>
 
-              <div className="nav-link">
+              <div className="nav-link d-md-none d-lg-block">
                 <Link href="/blog" passHref>
                   <Nav.Link> Blog</Nav.Link>
                 </Link>
@@ -259,7 +259,7 @@ export default function Navigation() {
             <Link href="/get-started" passHref>
               <Nav.Link>
                 <Button
-                  style={{ minWidth: 188 }}
+                  style={{ minWidth: 145 }}
                   variant="secondary"
                   size="sm"
                   className="col-12 col-md-3 col-lg-2 mx-0 ms-lg-2 mt-3 rounded-pill"


### PR DESCRIPTION
## Change description

Fixes an overflow issue on the nav when in `md` size by shrinking the Get Started button a bit and hiding the `Blog` nav item.

Before:
![www grouparoo com_ (1)](https://user-images.githubusercontent.com/4368928/154300401-90561920-f614-4e51-b7fa-ba7987d0a8e4.png)

After:
![localhost_3001_](https://user-images.githubusercontent.com/4368928/154300439-b98cc808-fd63-48a4-babe-787ecb9d5376.png)


## Checklists

### Development

- [ ] Application changes have been tested appropriately

### Impact

- [ ] Code follows company security practices and guidelines
- [ ] Security impact of change has been considered
- [ ] Performance impact of change has been considered
- [ ] Possible migration needs considered (model migrations, config migrations, etc.)

Please explain any security, performance, migration, or other impacts if relevant:

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached where applicable.
- [ ] Relevant tags have been added to the PR (bug, enhancement, internal, etc.)
